### PR TITLE
Use self instead of &self in value() and widen()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl<T: Copy, const BITS: usize> UInt<T, BITS> {
 
     /// Returns the type as a fundamental data type
     #[inline]
-    pub const fn value(&self) -> T {
+    pub const fn value(self) -> T {
         self.value
     }
 
@@ -248,7 +248,7 @@ macro_rules! uint_impl {
 
                 /// Returns a UInt with a wider bit depth but with the same base data type
                 pub const fn widen<const BITS_RESULT: usize>(
-                    &self,
+                    self,
                 ) -> UInt<$type, BITS_RESULT> {
                     let _ = CompileTimeAssert::<BITS, BITS_RESULT>::SMALLER_THAN;
                     // Query MAX of the result to ensure we get a compiler error if the current definition is bogus (e.g. <u8, 9>)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,6 +5,23 @@ use num_traits::WrappingAdd;
 use std::fmt::Debug;
 
 #[test]
+fn constants() {
+    // Make a constant to ensure new().value() works in a const-context
+    const TEST_CONSTANT: u8 = u7::new(127).value();
+    assert_eq!(TEST_CONSTANT, 127u8);
+
+    // Same with widen()
+    const TEST_CONSTANT2: u7 = u6::new(63).widen();
+    assert_eq!(TEST_CONSTANT2, u7::new(63));
+
+    // Same with widen()
+    const TEST_CONSTANT3A: Result<u6, TryNewError> = u6::try_new(62);
+    assert_eq!(TEST_CONSTANT3A, Ok(u6::new(62)));
+    const TEST_CONSTANT3B: Result<u6, TryNewError> = u6::try_new(64);
+    assert!(TEST_CONSTANT3B.is_err());
+}
+
+#[test]
 fn create_simple() {
     let value7 = u7::new(123);
     let value8 = UInt::<u8, 8>::new(189);


### PR DESCRIPTION
This ensures that value() is taken from the uX instead of Number, which isn't const.