### PR TITLE
Rename nightly to const_convert_and_const_trait_impl

### DIFF
--- a/.github/workflows/test-const.yml
+++ b/.github/workflows/test-const.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2023-04-01
+          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/test-const.yml
+++ b/.github/workflows/test-const.yml
@@ -1,0 +1,18 @@
+name: test num-traits
+run-name: ${{ github.actor }}'s patch
+on: [push]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features const_convert_and_const_trait_impl

--- a/.github/workflows/test-const.yml
+++ b/.github/workflows/test-const.yml
@@ -1,4 +1,4 @@
-name: test num-traits
+name: test const
 run-name: ${{ github.actor }}'s patch
 on: [push]
 jobs:
@@ -11,7 +11,7 @@ jobs:
           node-version: '14'
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-04-01
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Support `LowerHex`, `UpperHex`, `Octal`, `Binary` so that arbitrary-int can be printed via e.g. `format!("{:x}", u4::new(12))`
 - Support `Hash` so that arbitrary-int can be used in hash tables
 
+### Changed
+
+- As support for `[const_trait]` has recently been removed from structs like `From<T>` in upstream Rust, opting-in to the `nightly` feature no longer enables this behavior as that would break the build. To continue using this feature with older compiler versions, use `const_convert_and_const_trait_impl` instead.
+
 ## arbitrary-int 1.2.5
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,11 @@ categories = ["embedded", "no-std", "data-structures"]
 
 [features]
 std = []
-nightly = []
+
+# Supports const trait implementation through const_convert and const_trait_impl. Support for those was removed
+# from more recent Rust nightlies, so this feature requires an older Rust compiler
+# (2023-04-20 is broken, 2022-11-23 works. The exact day is somewhere inbetween)
+const_convert_and_const_trait_impl = []
 
 [dependencies]
 num-traits = { version = "0.2.15", default-features = false, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "nightly", feature(const_convert, const_trait_impl))]
+#![cfg_attr(
+    feature = "const_convert_and_const_trait_impl",
+    feature(const_convert, const_trait_impl)
+)]
 
 use core::fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, UpperHex};
 use core::hash::{Hash, Hasher};
@@ -19,7 +22,7 @@ impl Display for TryNewError {
     }
 }
 
-#[cfg_attr(feature = "nightly", const_trait)]
+#[cfg_attr(feature = "const_convert_and_const_trait_impl", const_trait)]
 pub trait Number: Sized {
     type UnderlyingType: Debug
         + From<u8>
@@ -44,7 +47,7 @@ pub trait Number: Sized {
     fn value(self) -> Self::UnderlyingType;
 }
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "const_convert_and_const_trait_impl")]
 macro_rules! impl_number_native {
     ($( $type:ty ),+) => {
         $(
@@ -67,7 +70,7 @@ macro_rules! impl_number_native {
     };
 }
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 macro_rules! impl_number_native {
     ($( $type:ty ),+) => {
         $(
@@ -137,7 +140,7 @@ where
 //   the subtraction overflows which will fail to compile. This simplifies things a lot.
 //   However, that only works if every constructor also uses MAX somehow (doing let _ = MAX is enough)
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "const_convert_and_const_trait_impl")]
 macro_rules! uint_impl_num {
     ($($type:ident),+) => {
         $(
@@ -177,7 +180,7 @@ macro_rules! uint_impl_num {
     };
 }
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 macro_rules! uint_impl_num {
     ($($type:ident),+) => {
         $(
@@ -897,7 +900,7 @@ bytes_operation_impl!(
 
 // Conversions
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "const_convert_and_const_trait_impl")]
 macro_rules! from_arbitrary_int_impl {
     ($from:ty, [$($into:ty),+]) => {
         $(
@@ -914,7 +917,7 @@ macro_rules! from_arbitrary_int_impl {
     };
 }
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 macro_rules! from_arbitrary_int_impl {
     ($from:ty, [$($into:ty),+]) => {
         $(
@@ -931,7 +934,7 @@ macro_rules! from_arbitrary_int_impl {
     };
 }
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "const_convert_and_const_trait_impl")]
 macro_rules! from_native_impl {
     ($from:ty, [$($into:ty),+]) => {
         $(
@@ -954,7 +957,7 @@ macro_rules! from_native_impl {
     };
 }
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 macro_rules! from_native_impl {
     ($from:ty, [$($into:ty),+]) => {
         $(
@@ -1011,7 +1014,7 @@ mod aliases {
 
 // We need to wrap this in a macro, currently: https://github.com/rust-lang/rust/issues/67792#issuecomment-1130369066
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "const_convert_and_const_trait_impl")]
 macro_rules! boolu1 {
     () => {
         impl const From<bool> for u1 {
@@ -1033,7 +1036,7 @@ macro_rules! boolu1 {
     };
 }
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 macro_rules! boolu1 {
     () => {
         impl From<bool> for u1 {


### PR DESCRIPTION
[const_trait] no longer works on the newest Rust, so this should have a more specific (and scary sounding) name.