### PR TITLE
Add optional defmt support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,9 @@ const_convert_and_const_trait_impl = []
 # core::fmt::Step is currently unstable and is available on nightly behind a feature gate
 step_trait = []
 
+# Supports defmt
+defmt = ["dep:defmt"]
+
 [dependencies]
 num-traits = { version = "0.2.15", default-features = false, optional = true }
+defmt = { version = "0.3.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -711,6 +711,17 @@ where
     }
 }
 
+#[cfg(feature = "defmt")]
+impl<T, const BITS: usize> defmt::Format for UInt<T, BITS>
+where
+    T: defmt::Format,
+{
+    #[inline]
+    fn format(&self, f: defmt::Formatter) {
+        self.value.format(f)
+    }
+}
+
 impl<T, const BITS: usize> Hash for UInt<T, BITS>
 where
     T: Hash,
@@ -750,7 +761,6 @@ where
         }
     }
 }
-
 
 #[cfg(feature = "num-traits")]
 impl<T, const NUM_BITS: usize> num_traits::WrappingAdd for UInt<T, NUM_BITS>


### PR DESCRIPTION
[`defmt`](https://defmt.ferrous-systems.com) is a popular crate in the embedded Rust ecosystem, and since this crate is `#[no_std]` aware, having support for it seems appropriate.

Thanks for your great crate!