### PR TITLE
Add serde support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support `Step` so that arbitrary-int can be used in a range expression, e.g. `for n in u3::MIN..=u3::MAX { println!("{n}") }`. Note this trait is currently unstable, and so is only usable in nightly. Enable this feature with `step_trait`.
 - Support formatting via [defmt](https://crates.io/crates/defmt). Enable the option `defmt` feature
+- Support serializing and deserializing via [serde](https://crates.io/crates/serde). Enable the option `serde` feature
 
 ## arbitrary-int 1.2.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,13 @@ step_trait = []
 # Supports defmt
 defmt = ["dep:defmt"]
 
+# Supports serde
+serde = ["dep:serde"]
+
 [dependencies]
 num-traits = { version = "0.2.15", default-features = false, optional = true }
 defmt = { version = "0.3.5", optional = true }
+serde = { version = "1.0.188", optional = true, default-features = false}
+
+[dev-dependencies]
+serde_test = "1.0.176"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = ["dep:serde"]
 [dependencies]
 num-traits = { version = "0.2.15", default-features = false, optional = true }
 defmt = { version = "0.3.5", optional = true }
-serde = { version = "1.0.188", optional = true, default-features = false}
+serde = { version = "1.0", optional = true, default-features = false}
 
 [dev-dependencies]
-serde_test = "1.0.176"
+serde_test = "1.0"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1373,3 +1373,29 @@ fn steps_between() {
         Step::steps_between(&u125::new(0x7), &u125::new(0x1_0000_0000_0000_0007))
     );
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn serde() {
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+
+    let a = u7::new(0b0101_0101);
+    assert_tokens(&a, &[Token::U8(0b0101_0101)]);
+
+    let b = u63::new(0x1234_5678_9ABC_DEFE);
+    assert_tokens(&b, &[Token::U64(0x1234_5678_9ABC_DEFE)]);
+
+    // This requires https://github.com/serde-rs/test/issues/18 (Add Token::I128 and Token::U128 to serde_test)
+    // let c = u127::new(0x1234_5678_9ABC_DEFE_DCBA_9876_5432_1010);
+    // assert_tokens(&c, &[Token::U128(0x1234_5678_9ABC_DEFE_DCBA_9876_5432_1010)]);
+
+    assert_de_tokens_error::<u2>(
+        &[Token::U8(0b0101_0101)],
+        "invalid value: integer `85`, expected a value between `0` and `3`",
+    );
+
+    assert_de_tokens_error::<u100>(
+        &[Token::I64(-1)],
+        "invalid value: integer `-1`, expected u128",
+    );
+}


### PR DESCRIPTION
Basic `Serialize` and `Deserialize` implementations for `UInt<T, BITS>` with graceful error handling and tests, gated by `serde` feature. A step towards closing https://github.com/hecatia-elegua/bilge/issues/74.