### PR TITLE
Add  hint to value()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ borsh = ["dep:borsh"]
 
 schemars = ["dep:schemars", "std"]
 
+# Provide a soundness promixe to the compiler that the unerlying value is always within range
+# This optimizes e.g. indexing range checks when passed in an API
+hint = []
+
 [dependencies]
 num-traits = { version = "0.2.19", default-features = false, optional = true }
 defmt = { version = "0.3.8", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,11 @@ macro_rules! uint_impl_num {
 
                 #[inline]
                 fn value(self) -> $type {
+                    #[cfg(feature = "hint")]
+                    unsafe {
+                        core::hint::assert_unchecked(self.value <= Self::MAX.value);
+                    }
+
                     self.value
                 }
             }
@@ -230,6 +235,11 @@ macro_rules! uint_impl_num {
 
                 #[inline]
                 fn value(self) -> $type {
+                    #[cfg(feature = "hint")]
+                    unsafe {
+                        core::hint::assert_unchecked(self.value <= Self::MAX.value);
+                    }
+
                     self.value
                 }
             }


### PR DESCRIPTION
The compiler is typically not smart enough to optimize away bounds checks if the arbitrary-int new()/value() API is not optimized away.

E.g. take this example:

```rust
#![no_std]

pub struct U<const N: usize>(u32);

impl<const N: usize> U<N> {
    const MAX: u32 = u32::MAX >> (32 - N);
    
    #[inline]
    pub const fn new(value: u32) -> Self {
        assert!(value <= Self::MAX);
        Self(value)
    }

    #[inline]
    pub const fn value(&self) -> u32 {
        // unsafe { core::hint::assert_unchecked(self.0 < 1 << N); }
        self.0
    }
}

#[inline(never)]
fn f(x: U<2>) -> i32 {
    const A: [i32; 4] = [1,8,9,0];
    A[x.value() as usize]
}

pub fn g(x: u32) -> i32 {
    f(U::new(x))
}
```

https://rust.godbolt.org/z/cYx6j666W

`f()` does a full bounds check even though U<2> is known to be an in-bounds index for a len-4 array.

Adding the [soundness promise](https://doc.rust-lang.org/std/hint/fn.assert_unchecked.html) that the return of `value()` does not exceed `MAX` (matching the assert in `new()`) enables the compiler to optimize away the check regardless of the value of the argument.

This is currently behind a feature gate (`hint`) but IMO it could just be blanket-added since the point of the crate is precisely to make that promise.