### PR TITLE
Run actions on pull requests

### DIFF
--- a/.github/workflows/test-borsh.yml
+++ b/.github/workflows/test-borsh.yml
@@ -1,6 +1,6 @@
 name: test borsh
 run-name: ${{ github.actor }}'s patch
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-const.yml
+++ b/.github/workflows/test-const.yml
@@ -1,6 +1,6 @@
 name: test const
 run-name: ${{ github.actor }}'s patch
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-debug.yml
+++ b/.github/workflows/test-debug.yml
@@ -1,6 +1,6 @@
 name: test debug
 run-name: ${{ github.actor }}'s patch
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-hint.yml
+++ b/.github/workflows/test-hint.yml
@@ -1,6 +1,6 @@
 name: test release
 run-name: ${{ github.actor }}'s patch
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-num-traits.yml
+++ b/.github/workflows/test-num-traits.yml
@@ -1,6 +1,6 @@
 name: test num-traits
 run-name: ${{ github.actor }}'s patch
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,6 +1,6 @@
 name: test release
 run-name: ${{ github.actor }}'s patch
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-serde.yml
+++ b/.github/workflows/test-serde.yml
@@ -1,6 +1,6 @@
 name: test serde
 run-name: ${{ github.actor }}'s patch
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-step.yml
+++ b/.github/workflows/test-step.yml
@@ -1,6 +1,6 @@
 name: test step
 run-name: ${{ github.actor }}'s patch
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
PRs sent from outside don't currently run GitHub actions. This makes it impossible to see if tests fail.

This should fix it - though we won't know until another PR is rebased.