### PR TITLE
Implement saturating arithmetic functions for signed integers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## arbitrary-int 1.4.0
+## arbitrary-int 1.4.0 (unreleased)
 
 ### Added
 
@@ -9,7 +9,6 @@
     * Support for the following optional Cargo features: `serde`, `step_trait`, `defmt`, `borsh` and `schemars`
     * Byte operations (`to_ne_bytes`, ...)
     * Extract functions (`extract_i8`, ...)
-    * Saturating arithmetic functions (`saturating_add`, ...)
     * Checked arithmetic functions (`checked_add`, ...)
     * Overflowing arithmetic functions (`overflowing_add`, ...)
 

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -460,6 +460,20 @@ macro_rules! int_impl {
                     Int::<$type, BITS_RESULT> { value: self.value }
                 }
 
+                /// Wrapping (modular) addition. Computes `self + rhs`, wrapping around at the
+                /// boundary of the type.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::{i14, SignedNumber};
+                /// assert_eq!(i14::new(100).wrapping_add(i14::new(27)), i14::new(127));
+                /// assert_eq!(i14::MAX.wrapping_add(i14::new(2)), i14::MIN + i14::new(1));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_add(self, rhs: Self) -> Self {
                     let sum = self.value.wrapping_add(rhs.value);
                     Self {
@@ -467,6 +481,20 @@ macro_rules! int_impl {
                     }
                 }
 
+                /// Wrapping (modular) subtraction. Computes `self - rhs`, wrapping around at the
+                /// boundary of the type.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::{i14, SignedNumber};
+                /// assert_eq!(i14::new(0).wrapping_sub(i14::new(127)), i14::new(-127));
+                /// assert_eq!(i14::new(-2).wrapping_sub(i14::MAX), i14::MAX);
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_sub(self, rhs: Self) -> Self {
                     let sum = self.value.wrapping_sub(rhs.value);
                     Self {
@@ -474,6 +502,20 @@ macro_rules! int_impl {
                     }
                 }
 
+                /// Wrapping (modular) multiplication. Computes `self * rhs`, wrapping around at the
+                /// boundary of the type.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::i14;
+                /// assert_eq!(i14::new(10).wrapping_mul(i14::new(12)), i14::new(120));
+                /// assert_eq!(i14::new(12).wrapping_mul(i14::new(1024)), i14::new(-4096));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_mul(self, rhs: Self) -> Self {
                     let sum = self.value.wrapping_mul(rhs.value);
                     Self {
@@ -481,6 +523,29 @@ macro_rules! int_impl {
                     }
                 }
 
+                /// Wrapping (modular) division. Computes `self / rhs`, wrapping around at the
+                /// boundary of the type.
+                ///
+                /// The only case where such wrapping can occur is when one divides `MIN / -1` on a
+                /// signed type (where `MIN` is the negative minimal value for the type); this is
+                /// equivalent to `-MIN`, a positive value that is too large to represent in the type.
+                /// In such a case, this function returns `MIN` itself.
+                ///
+                /// # Panics
+                ///
+                /// This function will panic if `rhs` is zero.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::{i14, SignedNumber};
+                /// assert_eq!(i14::new(100).wrapping_div(i14::new(10)), i14::new(10));
+                /// assert_eq!(i14::MIN.wrapping_div(i14::new(-1)), i14::MIN);
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_div(self, rhs: Self) -> Self {
                     let sum = self.value.wrapping_div(rhs.value);
                     Self {
@@ -490,6 +555,24 @@ macro_rules! int_impl {
                     }
                 }
 
+                /// Panic-free bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
+                /// high-order bits of `rhs` that would cause the shift to exceed the bitwidth of the type.
+                ///
+                /// Note that this is not the same as a rotate-left; the RHS of a wrapping shift-left is
+                /// restricted to the range of the type, rather than the bits shifted out of the LHS being
+                /// returned to the other end.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::i14;
+                /// assert_eq!(i14::new(-1).wrapping_shl(7), i14::new(-128));
+                /// assert_eq!(i14::new(-1).wrapping_shl(128), i14::new(-4));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_shl(self, rhs: u32) -> Self {
                     // modulo is expensive on some platforms, so only do it when necessary
                     let shift_amount = Self::UNUSED_BITS as u32 + (if rhs >= BITS as u32 {
@@ -507,6 +590,24 @@ macro_rules! int_impl {
                     }
                 }
 
+                /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`, where mask removes any
+                /// high-order bits of `rhs` that would cause the shift to exceed the bitwidth of the type.
+                ///
+                /// Note that this is not the same as a rotate-right; the RHS of a wrapping shift-right is
+                /// restricted to the range of the type, rather than the bits shifted out of the LHS being
+                /// returned to the other end.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::i14;
+                /// assert_eq!(i14::new(-128).wrapping_shr(7), i14::new(-1));
+                /// assert_eq!(i14::new(-128).wrapping_shr(60), i14::new(-8));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_shr(self, rhs: u32) -> Self {
                     // modulo is expensive on some platforms, so only do it when necessary
                     let shift_amount = if rhs >= (BITS as u32) {

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -365,6 +365,7 @@ macro_rules! int_impl {
                 /// ```
                 /// To convert from the bitwise representation back to an instance, use [`Self::from_bits`].
                 #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn to_bits(self) -> $unsigned_type {
                     (self.value() & Self::MASK) as $unsigned_type
                 }
@@ -452,6 +453,8 @@ macro_rules! int_impl {
                 }
 
                 /// Returns an [`Int`] with a wider bit depth but with the same base data type
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn widen<const BITS_RESULT: usize>(self) -> Int<$type, BITS_RESULT> {
                     const { assert!(BITS < BITS_RESULT, "Can not call widen() with the given bit widths") };
 

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -459,6 +459,20 @@ macro_rules! uint_impl {
                     UInt::<$type, BITS_RESULT> { value: self.value }
                 }
 
+                /// Wrapping (modular) addition. Computes `self + rhs`, wrapping around at the
+                /// boundary of the type.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::{u14, Number};
+                /// assert_eq!(u14::new(200).wrapping_add(u14::new(55)), u14::new(255));
+                /// assert_eq!(u14::new(200).wrapping_add(u14::MAX), u14::new(199));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_add(self, rhs: Self) -> Self {
                     let sum = self.value.wrapping_add(rhs.value);
                     Self {
@@ -466,6 +480,20 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Wrapping (modular) subtraction. Computes `self - rhs`, wrapping around at the
+                /// boundary of the type.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::{u14, Number};
+                /// assert_eq!(u14::new(100).wrapping_sub(u14::new(100)), u14::new(0));
+                /// assert_eq!(u14::new(100).wrapping_sub(u14::MAX), u14::new(101));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_sub(self, rhs: Self) -> Self {
                     let sum = self.value.wrapping_sub(rhs.value);
                     Self {
@@ -473,6 +501,20 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Wrapping (modular) multiplication. Computes `self * rhs`, wrapping around at the
+                /// boundary of the type.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::u7;
+                /// assert_eq!(u7::new(10).wrapping_mul(u7::new(12)), u7::new(120));
+                /// assert_eq!(u7::new(25).wrapping_mul(u7::new(12)), u7::new(44));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_mul(self, rhs: Self) -> Self {
                     let sum = self.value.wrapping_mul(rhs.value);
                     Self {
@@ -480,6 +522,26 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Wrapping (modular) division. Computes `self / rhs`.
+                ///
+                /// Wrapped division on unsigned types is just normal division. There’s no way
+                /// wrapping could ever happen. This function exists so that all operations are
+                /// accounted for in the wrapping operations.
+                ///
+                /// # Panics
+                ///
+                /// This function will panic if `rhs` is zero.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::u14;
+                /// assert_eq!(u14::new(100).wrapping_div(u14::new(10)), u14::new(10));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_div(self, rhs: Self) -> Self {
                     let sum = self.value.wrapping_div(rhs.value);
                     Self {
@@ -488,6 +550,25 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Panic-free bitwise shift-left; yields `self << mask(rhs)`, where mask
+                /// removes any high-order bits of `rhs` that would cause the shift to
+                /// exceed the bitwidth of the type.
+                ///
+                /// Note that this is not the same as a rotate-left; the RHS of a wrapping
+                /// shift-left is restricted to the range of the type, rather than the bits
+                /// shifted out of the LHS being returned to the other end.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::u14;
+                /// assert_eq!(u14::new(1).wrapping_shl(7), u14::new(128));
+                /// assert_eq!(u14::new(1).wrapping_shl(128), u14::new(4));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_shl(self, rhs: u32) -> Self {
                     // modulo is expensive on some platforms, so only do it when necessary
                     let shift_amount = if rhs >= (BITS as u32) {
@@ -505,6 +586,24 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`, where mask removes any
+                /// high-order bits of `rhs` that would cause the shift to exceed the bitwidth of the type.
+                ///
+                /// Note that this is not the same as a rotate-right; the RHS of a wrapping shift-right is
+                /// restricted to the range of the type, rather than the bits shifted out of the LHS being
+                /// returned to the other end.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::u14;
+                /// assert_eq!(u14::new(128).wrapping_shr(7), u14::new(1));
+                /// assert_eq!(u14::new(128).wrapping_shr(128), u14::new(32));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_shr(self, rhs: u32) -> Self {
                     // modulo is expensive on some platforms, so only do it when necessary
                     let shift_amount = if rhs >= (BITS as u32) {

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -446,7 +446,9 @@ macro_rules! uint_impl {
                     }
                 }
 
-                /// Returns a UInt with a wider bit depth but with the same base data type
+                /// Returns a [`UInt`] with a wider bit depth but with the same base data type
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn widen<const BITS_RESULT: usize>(
                     self,
                 ) -> UInt<$type, BITS_RESULT> {
@@ -882,18 +884,22 @@ macro_rules! uint_impl {
                 }
 
                 /// Reverses the order of bits in the integer. The least significant bit becomes the most significant bit, second least-significant bit becomes second most-significant bit, etc.
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn reverse_bits(self) -> Self {
                     let shift_right = (core::mem::size_of::<$type>() << 3) - BITS;
                     Self { value: self.value.reverse_bits() >> shift_right }
                 }
 
                 /// Returns the number of ones in the binary representation of self.
+                #[inline]
                 pub const fn count_ones(self) -> u32 {
                     // The upper bits are zero, so we can ignore them
                     self.value.count_ones()
                 }
 
                 /// Returns the number of zeros in the binary representation of self.
+                #[inline]
                 pub const fn count_zeros(self) -> u32 {
                     // The upper bits are zero, so we can have to subtract them from the result
                     let filler_bits = ((core::mem::size_of::<$type>() << 3) - BITS) as u32;
@@ -901,29 +907,35 @@ macro_rules! uint_impl {
                 }
 
                 /// Returns the number of leading ones in the binary representation of self.
+                #[inline]
                 pub const fn leading_ones(self) -> u32 {
                     let shift = ((core::mem::size_of::<$type>() << 3) - BITS) as u32;
                     (self.value << shift).leading_ones()
                 }
 
                 /// Returns the number of leading zeros in the binary representation of self.
+                #[inline]
                 pub const fn leading_zeros(self) -> u32 {
                     let shift = ((core::mem::size_of::<$type>() << 3) - BITS) as u32;
                     (self.value << shift).leading_zeros()
                 }
 
                 /// Returns the number of leading ones in the binary representation of self.
+                #[inline]
                 pub const fn trailing_ones(self) -> u32 {
                     self.value.trailing_ones()
                 }
 
                 /// Returns the number of leading zeros in the binary representation of self.
+                #[inline]
                 pub const fn trailing_zeros(self) -> u32 {
                     self.value.trailing_zeros()
                 }
 
                 /// Shifts the bits to the left by a specified amount, n, wrapping the truncated bits to the end of the resulting integer.
                 /// Please note this isn't the same operation as the << shifting operator!
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn rotate_left(self, n: u32) -> Self {
                     let b = BITS as u32;
                     let n = if n >= b { n % b } else { n };
@@ -935,6 +947,8 @@ macro_rules! uint_impl {
 
                 /// Shifts the bits to the right by a specified amount, n, wrapping the truncated bits to the beginning of the resulting integer.
                 /// Please note this isn't the same operation as the >> shifting operator!
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn rotate_right(self, n: u32) -> Self {
                     let b = BITS as u32;
                     let n = if n >= b { n % b } else { n };

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -518,9 +518,25 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Saturating integer addition. Computes `self + rhs`, saturating at the numeric
+                /// bounds instead of overflowing.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::{u14, Number};
+                /// assert_eq!(u14::new(100).saturating_add(u14::new(1)), u14::new(101));
+                /// assert_eq!(u14::MAX.saturating_add(u14::new(100)), u14::MAX);
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn saturating_add(self, rhs: Self) -> Self {
                     let saturated = if core::mem::size_of::<$type>() << 3 == BITS {
-                        // We are something like a UInt::<u8; 8>. We can fallback to the base implementation
+                        // We are something like a UInt::<u8; 8>, we can fallback to the base implementation.
+                        // This is very unlikely to happen in practice, but checking allows us to use
+                        // `wrapping_add` instead of `saturating_add` in the common case, which is faster.
                         self.value.saturating_add(rhs.value)
                     } else {
                         // We're dealing with fewer bits than the underlying type (e.g. u7).
@@ -534,6 +550,20 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Saturating integer subtraction. Computes `self - rhs`, saturating at the numeric
+                /// bounds instead of overflowing.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::u14;
+                /// assert_eq!(u14::new(100).saturating_sub(u14::new(27)), u14::new(73));
+                /// assert_eq!(u14::new(13).saturating_sub(u14::new(127)), u14::new(0));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn saturating_sub(self, rhs: Self) -> Self {
                     // For unsigned numbers, the only difference is when we reach 0 - which is the same
                     // no matter the data size
@@ -542,6 +572,20 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Saturating integer multiplication. Computes `self * rhs`, saturating at the numeric
+                /// bounds instead of overflowing.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::{u14, Number};
+                /// assert_eq!(u14::new(2).saturating_mul(u14::new(10)), u14::new(20));
+                /// assert_eq!(u14::MAX.saturating_mul(u14::new(10)), u14::MAX);
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn saturating_mul(self, rhs: Self) -> Self {
                     let product = if BITS << 1 <= (core::mem::size_of::<$type>() << 3) {
                         // We have half the bits (e.g. u4 * u4) of the base type, so we can't overflow the base type
@@ -559,6 +603,23 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Saturating integer division. Computes `self / rhs`, saturating at the numeric
+                /// bounds instead of overflowing.
+                ///
+                /// # Panics
+                ///
+                /// This function will panic if rhs is zero.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::u14;
+                /// assert_eq!(u14::new(5).saturating_div(u14::new(2)), u14::new(2));
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn saturating_div(self, rhs: Self) -> Self {
                     // When dividing unsigned numbers, we never need to saturate.
                     // Division by zero in saturating_div throws an exception (in debug and release mode),
@@ -568,9 +629,23 @@ macro_rules! uint_impl {
                     }
                 }
 
+                /// Saturating integer exponentiation. Computes `self.pow(exp)`, saturating at the numeric
+                /// bounds instead of overflowing.
+                ///
+                /// # Examples
+                ///
+                /// Basic usage:
+                ///
+                /// ```
+                /// # use arbitrary_int::{u14, Number};
+                /// assert_eq!(u14::new(4).saturating_pow(3), u14::new(64));
+                /// assert_eq!(u14::MAX.saturating_pow(2), u14::MAX);
+                /// ```
+                #[inline]
+                #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn saturating_pow(self, exp: u32) -> Self {
                     // It might be possible to handwrite this to be slightly faster as both
-                    // saturating_pow has to do a bounds-check and then we do second one
+                    // `saturating_pow` has to do a bounds-check and then we do second one.
                     let powed = self.value.saturating_pow(exp);
                     let max = Self::MAX.value();
                     let saturated = if powed > max { max } else { powed };

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -378,7 +378,7 @@ macro_rules! uint_impl {
 
                 /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
                 /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient.
-                /// panics if start_bit+<number of bits> doesn't fit within an u8, e.g. u5::extract_u8(8, 4);
+                /// panics if `start_bit+<number of bits>` doesn't fit within an u8, e.g. `u5::extract_u8(8, 4)`;
                 #[inline]
                 pub const fn extract_u8(value: u8, start_bit: usize) -> Self {
                     assert!(start_bit + BITS <= 8);
@@ -392,7 +392,7 @@ macro_rules! uint_impl {
 
                 /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
                 /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient
-                /// panics if start_bit+<number of bits> doesn't fit within a u16, e.g. u15::extract_u16(8, 2);
+                /// panics if `start_bit+<number of bits>` doesn't fit within a u16, e.g. `u15::extract_u16(8, 2)`;
                 #[inline]
                 pub const fn extract_u16(value: u16, start_bit: usize) -> Self {
                     assert!(start_bit + BITS <= 16);
@@ -406,7 +406,7 @@ macro_rules! uint_impl {
 
                 /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
                 /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient
-                /// panics if start_bit+<number of bits> doesn't fit within a u32, e.g. u30::extract_u32(8, 4);
+                /// panics if `start_bit+<number of bits>` doesn't fit within a u32, e.g. `u30::extract_u32(8, 4)`;
                 #[inline]
                 pub const fn extract_u32(value: u32, start_bit: usize) -> Self {
                     assert!(start_bit + BITS <= 32);
@@ -420,7 +420,7 @@ macro_rules! uint_impl {
 
                 /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
                 /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient
-                /// panics if start_bit+<number of bits> doesn't fit within a u64, e.g. u60::extract_u64(8, 5);
+                /// panics if `start_bit+<number of bits>` doesn't fit within a u64, e.g. `u60::extract_u64(8, 5)`;
                 #[inline]
                 pub const fn extract_u64(value: u64, start_bit: usize) -> Self {
                     assert!(start_bit + BITS <= 64);
@@ -434,7 +434,7 @@ macro_rules! uint_impl {
 
                 /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
                 /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient
-                /// panics if start_bit+<number of bits> doesn't fit within a u128, e.g. u120::extract_u64(8, 9);
+                /// panics if `start_bit+<number of bits>` doesn't fit within a u128, e.g. `u120::extract_u64(8, 9)`;
                 #[inline]
                 pub const fn extract_u128(value: u128, start_bit: usize) -> Self {
                     assert!(start_bit + BITS <= 128);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2022,7 +2022,7 @@ fn wrapping_shr_signed() {
 }
 
 #[test]
-fn saturating_add() {
+fn saturating_add_unsigned() {
     assert_eq!(u7::new(120).saturating_add(u7::new(1)), u7::new(121));
     assert_eq!(u7::new(120).saturating_add(u7::new(10)), u7::new(127));
     assert_eq!(u7::new(127).saturating_add(u7::new(127)), u7::new(127));
@@ -2033,7 +2033,27 @@ fn saturating_add() {
 }
 
 #[test]
-fn saturating_sub() {
+fn saturating_add_signed() {
+    assert_eq!(i7::new(60).saturating_add(i7::new(1)), i7::new(61));
+    assert_eq!(i7::new(60).saturating_add(i7::new(-1)), i7::new(59));
+
+    assert_eq!(i7::new(-60).saturating_add(i7::new(1)), i7::new(-59));
+    assert_eq!(i7::new(-60).saturating_add(i7::new(-1)), i7::new(-61));
+
+    assert_eq!(i7::new(63).saturating_add(i7::new(10)), i7::new(63));
+    assert_eq!(i7::new(63).saturating_add(i7::new(63)), i7::new(63));
+
+    assert_eq!(i7::new(-64).saturating_add(i7::new(-10)), i7::new(-64));
+    assert_eq!(i7::new(-64).saturating_add(i7::new(-64)), i7::new(-64));
+
+    assert_eq!(
+        Int::<i8, 8>::new(120).saturating_add(Int::<i8, 8>::new(10)),
+        Int::<i8, 8>::new(127)
+    );
+}
+
+#[test]
+fn saturating_sub_unsigned() {
     assert_eq!(u7::new(120).saturating_sub(u7::new(30)), u7::new(90));
     assert_eq!(u7::new(120).saturating_sub(u7::new(119)), u7::new(1));
     assert_eq!(u7::new(120).saturating_sub(u7::new(120)), u7::new(0));
@@ -2042,7 +2062,30 @@ fn saturating_sub() {
 }
 
 #[test]
-fn saturating_mul() {
+fn saturating_sub_signed() {
+    assert_eq!(i7::new(60).saturating_sub(i7::new(30)), i7::new(30));
+    assert_eq!(i7::new(-60).saturating_sub(i7::new(-30)), i7::new(-30));
+
+    assert_eq!(i7::new(30).saturating_sub(i7::new(-30)), i7::new(60));
+    assert_eq!(i7::new(-30).saturating_sub(i7::new(30)), i7::new(-60));
+
+    assert_eq!(i7::new(63).saturating_sub(i7::new(62)), i7::new(1));
+    assert_eq!(i7::new(-63).saturating_sub(i7::new(-64)), i7::new(1));
+
+    assert_eq!(i7::new(-2).saturating_sub(i7::new(63)), i7::new(-64));
+    assert_eq!(i7::new(60).saturating_sub(i7::new(-6)), i7::new(63));
+
+    assert_eq!(i7::new(63).saturating_sub(i7::new(-64)), i7::new(63));
+    assert_eq!(i7::new(-64).saturating_sub(i7::new(63)), i7::new(-64));
+
+    assert_eq!(
+        Int::<i8, 8>::new(-128).saturating_sub(Int::<i8, 8>::new(10)),
+        Int::<i8, 8>::new(-128)
+    );
+}
+
+#[test]
+fn saturating_mul_unsigned() {
     // Fast-path: Only the arbitrary int is bounds checked
     assert_eq!(u4::new(5).saturating_mul(u4::new(2)), u4::new(10));
     assert_eq!(u4::new(5).saturating_mul(u4::new(3)), u4::new(15));
@@ -2064,7 +2107,47 @@ fn saturating_mul() {
 }
 
 #[test]
-fn saturating_div() {
+fn saturating_mul_signed() {
+    // Fast-path: Only the arbitrary int is bounds checked
+    assert_eq!(i4::new(2).saturating_mul(i4::new(2)), i4::new(4));
+    assert_eq!(i4::new(2).saturating_mul(i4::new(3)), i4::new(6));
+    assert_eq!(i4::new(2).saturating_mul(i4::new(4)), i4::new(7));
+
+    assert_eq!(i4::new(-2).saturating_mul(i4::new(2)), i4::new(-4));
+    assert_eq!(i4::new(-2).saturating_mul(i4::new(3)), i4::new(-6));
+    assert_eq!(i4::new(-2).saturating_mul(i4::new(4)), i4::new(-8));
+
+    assert_eq!(i4::new(2).saturating_mul(i4::new(-2)), i4::new(-4));
+    assert_eq!(i4::new(2).saturating_mul(i4::new(-3)), i4::new(-6));
+    assert_eq!(i4::new(2).saturating_mul(i4::new(-4)), i4::new(-8));
+
+    assert_eq!(i4::new(-2).saturating_mul(i4::new(-2)), i4::new(4));
+    assert_eq!(i4::new(-2).saturating_mul(i4::new(-3)), i4::new(6));
+    assert_eq!(i4::new(-2).saturating_mul(i4::new(-4)), i4::new(7));
+
+    // Slow-path (well, one more comparison)
+    assert_eq!(i5::new(5).saturating_mul(i5::new(2)), i5::new(10));
+    assert_eq!(i5::new(5).saturating_mul(i5::new(3)), i5::new(15));
+    assert_eq!(i5::new(5).saturating_mul(i5::new(4)), i5::new(15));
+    assert_eq!(i5::new(5).saturating_mul(i5::new(5)), i5::new(15));
+    assert_eq!(i5::new(5).saturating_mul(i5::new(6)), i5::new(15));
+    assert_eq!(i5::new(5).saturating_mul(i5::new(7)), i5::new(15));
+
+    assert_eq!(i5::new(-5).saturating_mul(i5::new(2)), i5::new(-10));
+    assert_eq!(i5::new(-5).saturating_mul(i5::new(3)), i5::new(-15));
+    assert_eq!(i5::new(-5).saturating_mul(i5::new(4)), i5::new(-16));
+
+    assert_eq!(i5::new(5).saturating_mul(i5::new(-2)), i5::new(-10));
+    assert_eq!(i5::new(5).saturating_mul(i5::new(-3)), i5::new(-15));
+    assert_eq!(i5::new(5).saturating_mul(i5::new(-4)), i5::new(-16));
+
+    assert_eq!(i5::new(-5).saturating_mul(i5::new(-2)), i5::new(10));
+    assert_eq!(i5::new(-5).saturating_mul(i5::new(-3)), i5::new(15));
+    assert_eq!(i5::new(-5).saturating_mul(i5::new(-4)), i5::new(15));
+}
+
+#[test]
+fn saturating_div_unsigned() {
     assert_eq!(u4::new(5).saturating_div(u4::new(1)), u4::new(5));
     assert_eq!(u4::new(5).saturating_div(u4::new(2)), u4::new(2));
     assert_eq!(u4::new(5).saturating_div(u4::new(3)), u4::new(1));
@@ -2074,19 +2157,72 @@ fn saturating_div() {
 
 #[test]
 #[should_panic]
-fn saturating_divby0() {
+fn saturating_divby0_unsigned() {
     // saturating_div throws an exception on zero
     let _ = u4::new(5).saturating_div(u4::new(0));
 }
 
 #[test]
-fn saturating_pow() {
+fn saturating_div_signed() {
+    assert_eq!(i5::MIN.saturating_div(i5::new(-1)), i5::MAX);
+
+    assert_eq!(i5::new(5).saturating_div(i5::new(1)), i5::new(5));
+    assert_eq!(i5::new(5).saturating_div(i5::new(2)), i5::new(2));
+    assert_eq!(i5::new(5).saturating_div(i5::new(3)), i5::new(1));
+    assert_eq!(i5::new(5).saturating_div(i5::new(4)), i5::new(1));
+    assert_eq!(i5::new(5).saturating_div(i5::new(5)), i5::new(1));
+
+    assert_eq!(i5::new(-5).saturating_div(i5::new(1)), i5::new(-5));
+    assert_eq!(i5::new(-5).saturating_div(i5::new(2)), i5::new(-2));
+    assert_eq!(i5::new(-5).saturating_div(i5::new(3)), i5::new(-1));
+    assert_eq!(i5::new(-5).saturating_div(i5::new(4)), i5::new(-1));
+    assert_eq!(i5::new(-5).saturating_div(i5::new(5)), i5::new(-1));
+
+    assert_eq!(i5::new(5).saturating_div(i5::new(-1)), i5::new(-5));
+    assert_eq!(i5::new(5).saturating_div(i5::new(-2)), i5::new(-2));
+    assert_eq!(i5::new(5).saturating_div(i5::new(-3)), i5::new(-1));
+    assert_eq!(i5::new(5).saturating_div(i5::new(-4)), i5::new(-1));
+    assert_eq!(i5::new(5).saturating_div(i5::new(-5)), i5::new(-1));
+
+    assert_eq!(i5::new(-5).saturating_div(i5::new(-1)), i5::new(5));
+    assert_eq!(i5::new(-5).saturating_div(i5::new(-2)), i5::new(2));
+    assert_eq!(i5::new(-5).saturating_div(i5::new(-3)), i5::new(1));
+    assert_eq!(i5::new(-5).saturating_div(i5::new(-4)), i5::new(1));
+    assert_eq!(i5::new(-5).saturating_div(i5::new(-5)), i5::new(1));
+}
+
+#[test]
+#[should_panic]
+fn saturating_divby0_signed() {
+    // saturating_div throws an exception on zero
+    let _ = i4::new(5).saturating_div(i4::new(0));
+}
+
+#[test]
+fn saturating_pow_unsigned() {
     assert_eq!(u7::new(5).saturating_pow(0), u7::new(1));
     assert_eq!(u7::new(5).saturating_pow(1), u7::new(5));
     assert_eq!(u7::new(5).saturating_pow(2), u7::new(25));
     assert_eq!(u7::new(5).saturating_pow(3), u7::new(125));
     assert_eq!(u7::new(5).saturating_pow(4), u7::new(127));
     assert_eq!(u7::new(5).saturating_pow(255), u7::new(127));
+}
+
+#[test]
+fn saturating_pow_signed() {
+    assert_eq!(i7::new(5).saturating_pow(0), i7::new(1));
+    assert_eq!(i7::new(5).saturating_pow(1), i7::new(5));
+    assert_eq!(i7::new(5).saturating_pow(2), i7::new(25));
+    assert_eq!(i7::new(5).saturating_pow(3), i7::new(63));
+    assert_eq!(i7::new(5).saturating_pow(4), i7::new(63));
+    assert_eq!(i7::new(5).saturating_pow(255), i7::new(63));
+
+    assert_eq!(i7::new(-5).saturating_pow(0), i7::new(1));
+    assert_eq!(i7::new(-5).saturating_pow(1), i7::new(-5));
+    assert_eq!(i7::new(-5).saturating_pow(2), i7::new(25));
+    assert_eq!(i7::new(-5).saturating_pow(3), i7::new(-64));
+    assert_eq!(i7::new(-5).saturating_pow(4), i7::new(63));
+    assert_eq!(i7::new(-5).saturating_pow(255), i7::new(-64));
 }
 
 #[test]


### PR DESCRIPTION
This PR adds the `saturating_*` family of functions to `Int`, bringing it one step closer to having an equivalent API as `UInt`. 

While implementing this I took a look at the standard library's implementation of the same functions, and noticed we can make use of their documentation (and doctests) with fairly little effort. I've copied over the documentation of the `wrapping_*` and `saturating_*` functions for both signed and unsigned integers, and plan to do the same for `checked_*`/`overflowing_*` when I get around to implementing those for signed integers.

I also noticed they had a `#[must_use]` attribute on all of these functions to indicate that `self` is not modified but the result is returned instead, which seemed like a good thing to introduce here as well.

`cargo doc` seemed to have a few warnings which this PR fixes, it might be nice to introduce a check for those in CI?