### PR TITLE
Add `serde` support for signed integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - New types for signed integers: `i1`, ..., `i127`. They have a similar API to unsigned integers, though a few
   features currently remain exclusive to unsigned integers:
-    * Support for the following optional Cargo features: `serde`, `step_trait`, `defmt`, `borsh` and `schemars`
+    * Support for the following optional Cargo features: `step_trait`, `defmt`, `borsh` and `schemars`
     * Byte operations (`to_ne_bytes`, ...)
     * Extract functions (`extract_i8`, ...)
     * Saturating arithmetic functions (`saturating_add`, ...)

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -858,6 +858,65 @@ where
     }
 }
 
+// Serde's invalid_value error (https://rust-lang.github.io/hashbrown/serde/de/trait.Error.html#method.invalid_value)
+// takes an Unexpected (https://rust-lang.github.io/hashbrown/serde/de/enum.Unexpected.html) which only accepts a 64 bit
+// integer. This is a problem for us because we want to support 128 bit integers. To work around this we define our own
+// error type using the Int's underlying type which implements Display and then use serde::de::Error::custom to create
+// an error with our custom type.
+#[cfg(feature = "serde")]
+struct InvalidIntValueError<T>
+where
+    T: SignedNumber,
+    T::UnderlyingType: fmt::Display,
+{
+    value: T::UnderlyingType,
+}
+
+#[cfg(feature = "serde")]
+impl<T> fmt::Display for InvalidIntValueError<T>
+where
+    T: SignedNumber,
+    T::UnderlyingType: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid value: integer `{}`, expected a value between `{}` and `{}`",
+            self.value,
+            T::MIN.value(),
+            T::MAX.value()
+        )
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T, const BITS: usize> serde::Serialize for Int<T, BITS>
+where
+    T: serde::Serialize,
+{
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.value.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, T, const BITS: usize> serde::Deserialize<'de> for Int<T, BITS>
+where
+    Self: SignedNumber<UnderlyingType = T>,
+    T: fmt::Display + PartialOrd + serde::Deserialize<'de>,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = T::deserialize(deserializer)?;
+
+        if value >= Self::MIN.value && value <= Self::MAX.value {
+            Ok(Self { value })
+        } else {
+            let err = InvalidIntValueError::<Self> { value };
+            Err(serde::de::Error::custom(err))
+        }
+    }
+}
+
 // Conversions
 from_arbitrary_int_impl!(Int(i8), [i16, i32, i64, i128]);
 from_arbitrary_int_impl!(Int(i16), [i8, i32, i64, i128]);

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1256,27 +1256,35 @@ where
 // we define our own error type using the UInt's underlying type which implements Display and then use
 // serde::de::Error::custom to create an error with our custom type.
 #[cfg(feature = "serde")]
-struct InvalidUIntValueError<T: Display> {
-    value: T,
-    max: T,
+struct InvalidUIntValueError<T>
+where
+    T: Number,
+    T::UnderlyingType: Display,
+{
+    value: T::UnderlyingType,
 }
 
 #[cfg(feature = "serde")]
-impl<T: Display> Display for InvalidUIntValueError<T> {
+impl<T> Display for InvalidUIntValueError<T>
+where
+    T: Number,
+    T::UnderlyingType: Display,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "invalid value: integer `{}`, expected a value between `0` and `{}`",
-            self.value, self.max
+            self.value,
+            T::MAX.value()
         )
     }
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T: Display, const BITS: usize> Deserialize<'de> for UInt<T, BITS>
+impl<'de, T, const BITS: usize> Deserialize<'de> for UInt<T, BITS>
 where
-    Self: Number,
-    T: Deserialize<'de> + PartialOrd,
+    Self: Number<UnderlyingType = T>,
+    T: Display + PartialOrd + Deserialize<'de>,
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let value = T::deserialize(deserializer)?;
@@ -1284,10 +1292,8 @@ where
         if value <= Self::MAX.value {
             Ok(Self { value })
         } else {
-            Err(serde::de::Error::custom(InvalidUIntValueError {
-                value,
-                max: Self::MAX.value,
-            }))
+            let err = InvalidUIntValueError::<Self> { value };
+            Err(serde::de::Error::custom(err))
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2503,8 +2503,8 @@ fn steps_between() {
 
 #[cfg(feature = "serde")]
 #[test]
-fn serde() {
-    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+fn serde_unsigned() {
+    use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
 
     let a = u7::new(0b0101_0101);
     assert_tokens(&a, &[Token::U8(0b0101_0101)]);
@@ -2525,6 +2525,52 @@ fn serde() {
         &[Token::I64(-1)],
         "invalid value: integer `-1`, expected u128",
     );
+
+    // Ensure that integer conversion is allowed as long as the values are within range.
+    // This matches the behavior of primitive types: https://docs.rs/serde/1.0.219/src/serde/de/impls.rs.html#302
+    assert_de_tokens(&u7::new(0), &[Token::I8(0)]);
+    assert_de_tokens(&u7::new(15), &[Token::I8(15)]);
+    assert_de_tokens(&u7::MAX, &[Token::I8(i8::MAX)]);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serde_signed() {
+    use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
+
+    let a = i7::new(55);
+    assert_tokens(&a, &[Token::I8(55)]);
+
+    let b = i7::new(-64);
+    assert_tokens(&b, &[Token::I8(-64)]);
+
+    let c = i63::new(0x1234_5678_9ABC_DEFE);
+    assert_tokens(&c, &[Token::I64(0x1234_5678_9ABC_DEFE)]);
+
+    // This requires https://github.com/serde-rs/test/issues/18 (Add Token::I128 and Token::U128 to serde_test)
+    // let c = u127::new(0x1234_5678_9ABC_DEFE_DCBA_9876_5432_1010);
+    // assert_tokens(&c, &[Token::U128(0x1234_5678_9ABC_DEFE_DCBA_9876_5432_1010)]);
+
+    assert_de_tokens_error::<i2>(
+        &[Token::U8(85)],
+        "invalid value: integer `85`, expected a value between `-2` and `1`",
+    );
+
+    assert_de_tokens_error::<i7>(
+        &[Token::I8(i8::MIN)],
+        "invalid value: integer `-128`, expected a value between `-64` and `63`",
+    );
+
+    assert_de_tokens_error::<i63>(
+        &[Token::U64(i64::MAX as u64 + 1)],
+        "invalid value: integer `9223372036854775808`, expected i64",
+    );
+
+    // Ensure that integer conversion is allowed as long as the values are within range.
+    // This matches the behavior of primitive types: https://docs.rs/serde/1.0.219/src/serde/de/impls.rs.html#347
+    assert_de_tokens(&i7::new(0), &[Token::U8(0)]);
+    assert_de_tokens(&i7::new(15), &[Token::U8(15)]);
+    assert_de_tokens(&i7::MAX, &[Token::U8(i7::MAX.value() as u8)]);
 }
 
 #[cfg(feature = "borsh")]


### PR DESCRIPTION
The only noteworthy decision here is that the serialized value is expected to come from `Int::value()` rather than `Int::to_bits()`, since that is easier to interpret both for humans and other tooling. 

I hope you don't mind the interleaved bits of cleanup in these signed integer PRs, I'd be happy to split it into different PRs if you prefer.