### PR TITLE
Implement extract functions for signed integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
   features currently remain exclusive to unsigned integers:
     * Support for the following optional Cargo features: `step_trait`, `defmt`, `borsh` and `schemars`
     * Byte operations (`to_ne_bytes`, ...)
-    * Extract functions (`extract_i8`, ...)
     * Checked arithmetic functions (`checked_add`, ...)
     * Overflowing arithmetic functions (`overflowing_add`, ...)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     * Byte operations (`to_ne_bytes`, ...)
     * Checked arithmetic functions (`checked_add`, ...)
     * Overflowing arithmetic functions (`overflowing_add`, ...)
+- Various new extract functions: `extract_i8`, `extract_i16`, ..., `extract_i128`. These are the same as the
+  equivalent `extract_u<N>` functions, but work with signed integers instead.
 
 ## arbitrary-int 1.3.0
 

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -452,17 +452,17 @@ macro_rules! int_impl {
                     self.value
                 }
 
-                // Generate the `extract_i{8,16,32,64,128}` functions.
+                // Generate the `extract_{i,u}{8,16,32,64,128}` functions.
                 impl_extract!(
                     $type,
                     "from_bits(value >> start_bit)",
                     |value| (value << Self::UNUSED_BITS) >> Self::UNUSED_BITS,
 
-                    (8, (i8, extract_i8)),
-                    (16, (i16, extract_i16)),
-                    (32, (i32, extract_i32)),
-                    (64, (i64, extract_i64)),
-                    (128, (i128, extract_i128))
+                    (8, (i8, extract_i8), (u8, extract_u8)),
+                    (16, (i16, extract_i16), (u16, extract_u16)),
+                    (32, (i32, extract_i32), (u32, extract_u32)),
+                    (64, (i64, extract_i64), (u64, extract_u64)),
+                    (128, (i128, extract_i128), (u128, extract_u128))
                 );
 
                 /// Returns an [`Int`] with a wider bit depth but with the same base data type

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{from_arbitrary_int_impl, from_native_impl},
+    common::{from_arbitrary_int_impl, from_native_impl, impl_extract},
     TryNewError,
 };
 use core::{
@@ -451,6 +451,19 @@ macro_rules! int_impl {
                     }
                     self.value
                 }
+
+                // Generate the `extract_i{8,16,32,64,128}` functions.
+                impl_extract!(
+                    $type,
+                    "from_bits(value >> start_bit)",
+                    |value| (value << Self::UNUSED_BITS) >> Self::UNUSED_BITS,
+
+                    (8, (i8, extract_i8)),
+                    (16, (i16, extract_i16)),
+                    (32, (i32, extract_i32)),
+                    (64, (i64, extract_i64)),
+                    (128, (i128, extract_i128))
+                );
 
                 /// Returns an [`Int`] with a wider bit depth but with the same base data type
                 #[inline]

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -376,17 +376,17 @@ macro_rules! uint_impl {
                     }
                 }
 
-                // Generate the `extract_u{8,16,32,64,128}` functions.
+                // Generate the `extract_{i,u}{8,16,32,64,128}` functions.
                 impl_extract!(
                     $type,
                     "new((value >> start_bit) & MASK)",
                     |value| value & Self::MASK,
 
-                    (8, (u8, extract_u8)),
-                    (16, (u16, extract_u16)),
-                    (32, (u32, extract_u32)),
-                    (64, (u64, extract_u64)),
-                    (128, (u128, extract_u128))
+                    (8, (u8, extract_u8), (i8, extract_i8)),
+                    (16, (u16, extract_u16), (i16, extract_i16)),
+                    (32, (u32, extract_u32), (i32, extract_i32)),
+                    (64, (u64, extract_u64), (i64, extract_i64)),
+                    (128, (u128, extract_u128), (i128, extract_i128))
                 );
 
                 /// Returns a [`UInt`] with a wider bit depth but with the same base data type

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1,4 +1,4 @@
-use crate::common::{from_arbitrary_int_impl, from_native_impl};
+use crate::common::{from_arbitrary_int_impl, from_native_impl, impl_extract};
 use crate::TryNewError;
 use core::fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, UpperHex};
 use core::hash::{Hash, Hasher};
@@ -376,75 +376,18 @@ macro_rules! uint_impl {
                     }
                 }
 
-                /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
-                /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient.
-                /// panics if `start_bit+<number of bits>` doesn't fit within an u8, e.g. `u5::extract_u8(8, 4)`;
-                #[inline]
-                pub const fn extract_u8(value: u8, start_bit: usize) -> Self {
-                    assert!(start_bit + BITS <= 8);
-                    // Query MAX to ensure that we get a compiler error if the current definition is bogus (e.g. <u8, 9>)
-                    let _ = Self::MAX;
+                // Generate the `extract_u{8,16,32,64,128}` functions.
+                impl_extract!(
+                    $type,
+                    "new((value >> start_bit) & MASK)",
+                    |value| value & Self::MASK,
 
-                    Self {
-                        value: ((value >> start_bit) as $type) & Self::MAX.value,
-                    }
-                }
-
-                /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
-                /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient
-                /// panics if `start_bit+<number of bits>` doesn't fit within a u16, e.g. `u15::extract_u16(8, 2)`;
-                #[inline]
-                pub const fn extract_u16(value: u16, start_bit: usize) -> Self {
-                    assert!(start_bit + BITS <= 16);
-                    // Query MAX to ensure that we get a compiler error if the current definition is bogus (e.g. <u8, 9>)
-                    let _ = Self::MAX;
-
-                    Self {
-                        value: ((value >> start_bit) as $type) & Self::MAX.value,
-                    }
-                }
-
-                /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
-                /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient
-                /// panics if `start_bit+<number of bits>` doesn't fit within a u32, e.g. `u30::extract_u32(8, 4)`;
-                #[inline]
-                pub const fn extract_u32(value: u32, start_bit: usize) -> Self {
-                    assert!(start_bit + BITS <= 32);
-                    // Query MAX to ensure that we get a compiler error if the current definition is bogus (e.g. <u8, 9>)
-                    let _ = Self::MAX;
-
-                    Self {
-                        value: ((value >> start_bit) as $type) & Self::MAX.value,
-                    }
-                }
-
-                /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
-                /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient
-                /// panics if `start_bit+<number of bits>` doesn't fit within a u64, e.g. `u60::extract_u64(8, 5)`;
-                #[inline]
-                pub const fn extract_u64(value: u64, start_bit: usize) -> Self {
-                    assert!(start_bit + BITS <= 64);
-                    // Query MAX to ensure that we get a compiler error if the current definition is bogus (e.g. <u8, 9>)
-                    let _ = Self::MAX;
-
-                    Self {
-                        value: ((value >> start_bit) as $type) & Self::MAX.value,
-                    }
-                }
-
-                /// Extracts bits from a given value. The extract is equivalent to: `new((value >> start_bit) & MASK)`
-                /// Unlike new, extract doesn't perform range-checking so it is slightly more efficient
-                /// panics if `start_bit+<number of bits>` doesn't fit within a u128, e.g. `u120::extract_u64(8, 9)`;
-                #[inline]
-                pub const fn extract_u128(value: u128, start_bit: usize) -> Self {
-                    assert!(start_bit + BITS <= 128);
-                    // Query MAX to ensure that we get a compiler error if the current definition is bogus (e.g. <u8, 9>)
-                    let _ = Self::MAX;
-
-                    Self {
-                        value: ((value >> start_bit) as $type) & Self::MAX.value,
-                    }
-                }
+                    (8, (u8, extract_u8)),
+                    (16, (u16, extract_u16)),
+                    (32, (u32, extract_u32)),
+                    (64, (u64, extract_u64)),
+                    (128, (u128, extract_u128))
+                );
 
                 /// Returns a [`UInt`] with a wider bit depth but with the same base data type
                 #[inline]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1025,6 +1025,21 @@ fn extract_typed_signed() {
 }
 
 #[test]
+fn extract_value_sign_extends() {
+    assert_eq!(-1, i5::extract_u64(0b0011_1110, 1).value());
+    assert_eq!(-1, i5::extract_i64(0b0011_1110, 1).value());
+
+    assert_eq!(-3, i5::extract_u32(0b0011_1010, 1).value());
+    assert_eq!(-3, i5::extract_i32(0b0011_1010, 1).value());
+
+    assert_eq!(-1, i3::extract_u8(0b0011_1000, 3).value());
+    assert_eq!(-1, i3::extract_i8(0b0011_1000, 3).value());
+
+    assert_eq!(-3, i3::extract_u8(0b0010_1000, 3).value());
+    assert_eq!(-3, i3::extract_i8(0b0010_1000, 3).value());
+}
+
+#[test]
 fn extract_full_width_typed_unsigned() {
     let (value_8, expected_8) = (0b1010_0011_u8, 0b1010_0011);
     assert_eq!(expected_8, UInt::<u8, 8>::extract_u8(value_8, 0).value());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -949,20 +949,34 @@ fn extract() {
 
 #[test]
 fn extract_typed_unsigned() {
-    assert_eq!(u5::new(0b10000), u5::extract_u8(0b11110000, 0));
-    assert_eq!(u5::new(0b00011), u5::extract_u16(0b11110000_11110110, 6));
-    assert_eq!(
-        u5::new(0b01011),
-        u5::extract_u32(0b11110010_11110110_00000000_00000000, 22)
+    let (value_8, expected_8) = (0b11110000_u8, 0b10000);
+    assert_eq!(u5::new(expected_8), u5::extract_u8(value_8, 0));
+    assert_eq!(u5::new(expected_8), u5::extract_i8(value_8 as i8, 0));
+
+    let (value_16, expected_16) = (0b11110000_11110110_u16, 0b00011);
+    assert_eq!(u5::new(expected_16), u5::extract_u16(value_16, 6));
+    assert_eq!(u5::new(expected_16), u5::extract_i16(value_16 as i16, 6));
+
+    let (value_32, expected_32) = (0b11110010_11110110_00000000_00000000_u32, 0b01011);
+    assert_eq!(u5::new(expected_32), u5::extract_u32(value_32, 22));
+    assert_eq!(u5::new(expected_32), u5::extract_i32(value_32 as i32, 22));
+
+    let (value_64, expected_64) = (
+        0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000_u64,
+        0b01011,
     );
-    assert_eq!(
-        u5::new(0b01011),
-        u5::extract_u64(
-            0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000,
-            54
-        )
+    assert_eq!(u5::new(expected_64), u5::extract_u64(value_64, 54));
+    assert_eq!(u5::new(expected_64), u5::extract_i64(value_64 as i64, 54));
+
+    let (value_128, expected_128) = (
+        0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_u128,
+        0b01011,
     );
-    assert_eq!(u5::new(0b01011), u5::extract_u128(0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000, 118));
+    assert_eq!(u5::new(expected_128), u5::extract_u128(value_128, 118));
+    assert_eq!(
+        u5::new(expected_128),
+        u5::extract_i128(value_128 as i128, 118)
+    );
 }
 
 #[test]
@@ -1012,13 +1026,18 @@ fn extract_typed_signed() {
 
 #[test]
 fn extract_full_width_typed_unsigned() {
+    let (value_8, expected_8) = (0b1010_0011_u8, 0b1010_0011);
+    assert_eq!(expected_8, UInt::<u8, 8>::extract_u8(value_8, 0).value());
     assert_eq!(
-        0b1010_0011,
-        UInt::<u8, 8>::extract_u8(0b1010_0011, 0).value()
+        expected_8,
+        UInt::<u8, 8>::extract_i8(value_8 as i8, 0).value()
     );
+
+    let (value_16, expected_16) = (0b1111_1111_1010_0011_u16, 0b1010_0011);
+    assert_eq!(expected_16, UInt::<u8, 8>::extract_u16(value_16, 0).value());
     assert_eq!(
-        0b1010_0011,
-        UInt::<u8, 8>::extract_u16(0b1111_1111_1010_0011, 0).value()
+        expected_16,
+        UInt::<u8, 8>::extract_i16(value_16 as i16, 0).value()
     );
 }
 
@@ -1041,6 +1060,12 @@ fn extract_full_width_typed_signed() {
         expected_16,
         Int::<i8, 8>::extract_u16(value_16, 0).to_bits()
     );
+}
+
+#[test]
+#[should_panic]
+fn extract_not_enough_bits_unsigned_with_signed_value() {
+    let _ = u5::extract_i8(0b11110000_u8 as i8, 4);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -968,35 +968,45 @@ fn extract_typed_unsigned() {
 #[test]
 fn extract_typed_signed() {
     // Note that binary literals cannot produce negative values, hence the `0b..._u8 as i8` casts.
-    assert_eq!(
-        i5::from_bits(0b10000),
-        i5::extract_i8(0b11110000_u8 as i8, 0)
-    );
+    let (value_8, expected_8) = (0b11110000_u8, 0b10000);
+    assert_eq!(i5::from_bits(expected_8), i5::extract_i8(value_8 as i8, 0));
+    assert_eq!(i5::from_bits(expected_8), i5::extract_u8(value_8, 0));
 
+    let (value_16, expected_16) = (0b11110000_11110110_u16, 0b00011);
     assert_eq!(
-        i5::from_bits(0b00011),
-        i5::extract_i16(0b11110000_11110110_u16 as i16, 6)
+        i5::from_bits(expected_16),
+        i5::extract_i16(value_16 as i16, 6)
     );
+    assert_eq!(i5::from_bits(expected_16), i5::extract_u16(value_16, 6));
 
+    let (value_32, expected_32) = (0b11110010_11110110_00000000_00000000_u32, 0b01011);
     assert_eq!(
-        i5::from_bits(0b01011),
-        i5::extract_i32(0b11110010_11110110_00000000_00000000_u32 as i32, 22)
+        i5::from_bits(expected_32),
+        i5::extract_i32(value_32 as i32, 22)
     );
+    assert_eq!(i5::from_bits(expected_32), i5::extract_u32(value_32, 22));
 
-    assert_eq!(
-        i5::from_bits(0b01011),
-        i5::extract_i64(
-            0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000_u64 as i64,
-            54
-        )
+    let (value_64, expected_64) = (
+        0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000_u64,
+        0b01011,
     );
-
     assert_eq!(
-        i5::from_bits(0b01011),
-        i5::extract_i128(
-            0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_u128 as i128,
-            118,
-        )
+        i5::from_bits(expected_64),
+        i5::extract_i64(value_64 as i64, 54)
+    );
+    assert_eq!(i5::from_bits(expected_64), i5::extract_u64(value_64, 54));
+
+    let (value_128, expected_128) = (
+        0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_u128,
+        0b01011,
+    );
+    assert_eq!(
+        i5::from_bits(expected_128),
+        i5::extract_i128(value_128 as i128, 118)
+    );
+    assert_eq!(
+        i5::from_bits(expected_128),
+        i5::extract_u128(value_128, 118)
     );
 }
 
@@ -1015,14 +1025,28 @@ fn extract_full_width_typed_unsigned() {
 #[test]
 fn extract_full_width_typed_signed() {
     // Note that binary literals cannot produce negative values, hence the `0b..._u8 as i8` casts.
+    let (value_8, expected_8) = (0b1010_0011_u8, 0b1010_0011);
     assert_eq!(
-        0b1010_0011,
-        Int::<i8, 8>::extract_i8(0b1010_0011_u8 as i8, 0).to_bits()
+        expected_8,
+        Int::<i8, 8>::extract_i8(value_8 as i8, 0).to_bits()
+    );
+    assert_eq!(expected_8, Int::<i8, 8>::extract_u8(value_8, 0).to_bits());
+
+    let (value_16, expected_16) = (0b1111_1111_1010_0011_u16, 0b1010_0011);
+    assert_eq!(
+        expected_16,
+        Int::<i8, 8>::extract_i16(value_16 as i16, 0).to_bits()
     );
     assert_eq!(
-        0b1010_0011,
-        Int::<i8, 8>::extract_i16(0b1111_1111_1010_0011_u16 as i16, 0).to_bits()
+        expected_16,
+        Int::<i8, 8>::extract_u16(value_16, 0).to_bits()
     );
+}
+
+#[test]
+#[should_panic]
+fn extract_not_enough_bits_signed_with_unsigned_value() {
+    let _ = i5::extract_u8(0b11110000, 4);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -948,7 +948,7 @@ fn extract() {
 }
 
 #[test]
-fn extract_typed() {
+fn extract_typed_unsigned() {
     assert_eq!(u5::new(0b10000), u5::extract_u8(0b11110000, 0));
     assert_eq!(u5::new(0b00011), u5::extract_u16(0b11110000_11110110, 6));
     assert_eq!(
@@ -966,7 +966,42 @@ fn extract_typed() {
 }
 
 #[test]
-fn extract_full_width_typed() {
+fn extract_typed_signed() {
+    // Note that binary literals cannot produce negative values, hence the `0b..._u8 as i8` casts.
+    assert_eq!(
+        i5::from_bits(0b10000),
+        i5::extract_i8(0b11110000_u8 as i8, 0)
+    );
+
+    assert_eq!(
+        i5::from_bits(0b00011),
+        i5::extract_i16(0b11110000_11110110_u16 as i16, 6)
+    );
+
+    assert_eq!(
+        i5::from_bits(0b01011),
+        i5::extract_i32(0b11110010_11110110_00000000_00000000_u32 as i32, 22)
+    );
+
+    assert_eq!(
+        i5::from_bits(0b01011),
+        i5::extract_i64(
+            0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000_u64 as i64,
+            54
+        )
+    );
+
+    assert_eq!(
+        i5::from_bits(0b01011),
+        i5::extract_i128(
+            0b11110010_11110110_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000_u128 as i128,
+            118,
+        )
+    );
+}
+
+#[test]
+fn extract_full_width_typed_unsigned() {
     assert_eq!(
         0b1010_0011,
         UInt::<u8, 8>::extract_u8(0b1010_0011, 0).value()
@@ -978,39 +1013,90 @@ fn extract_full_width_typed() {
 }
 
 #[test]
+fn extract_full_width_typed_signed() {
+    // Note that binary literals cannot produce negative values, hence the `0b..._u8 as i8` casts.
+    assert_eq!(
+        0b1010_0011,
+        Int::<i8, 8>::extract_i8(0b1010_0011_u8 as i8, 0).to_bits()
+    );
+    assert_eq!(
+        0b1010_0011,
+        Int::<i8, 8>::extract_i16(0b1111_1111_1010_0011_u16 as i16, 0).to_bits()
+    );
+}
+
+#[test]
 #[should_panic]
-fn extract_not_enough_bits_8() {
+fn extract_not_enough_bits_8_unsigned() {
     let _ = u5::extract_u8(0b11110000, 4);
 }
 
 #[test]
 #[should_panic]
-fn extract_not_enough_bits_8_full_width() {
+fn extract_not_enough_bits_8_signed() {
+    // Note that binary literals cannot produce negative values, hence `as` cast.
+    let _ = i5::extract_i8(0b11110000_u8 as i8, 4);
+}
+
+#[test]
+#[should_panic]
+fn extract_not_enough_bits_8_full_width_unsigned() {
     let _ = UInt::<u8, 8>::extract_u8(0b11110000, 1);
 }
 
 #[test]
 #[should_panic]
-fn extract_not_enough_bits_16() {
+fn extract_not_enough_bits_8_full_width_signed() {
+    // Note that binary literals cannot produce negative values, hence `as` cast.
+    let _ = Int::<i8, 8>::extract_i8(0b11110000_u8 as i8, 1);
+}
+
+#[test]
+#[should_panic]
+fn extract_not_enough_bits_16_unsigned() {
     let _ = u5::extract_u16(0b11110000, 12);
 }
 
 #[test]
 #[should_panic]
-fn extract_not_enough_bits_32() {
+fn extract_not_enough_bits_16_signed() {
+    let _ = i5::extract_i16(0b11110000, 12);
+}
+
+#[test]
+#[should_panic]
+fn extract_not_enough_bits_32_unsigned() {
     let _ = u5::extract_u32(0b11110000, 28);
 }
 
 #[test]
 #[should_panic]
-fn extract_not_enough_bits_64() {
+fn extract_not_enough_bits_32_signed() {
+    let _ = i5::extract_i32(0b11110000, 28);
+}
+
+#[test]
+#[should_panic]
+fn extract_not_enough_bits_64_unsigned() {
     let _ = u5::extract_u64(0b11110000, 60);
 }
 
 #[test]
 #[should_panic]
-fn extract_not_enough_bits_128() {
+fn extract_not_enough_bits_64_signed() {
+    let _ = i5::extract_i64(0b11110000, 60);
+}
+
+#[test]
+#[should_panic]
+fn extract_not_enough_bits_128_unsigned() {
     let _ = u5::extract_u128(0b11110000, 124);
+}
+
+#[test]
+#[should_panic]
+fn extract_not_enough_bits_128_signed() {
+    let _ = i5::extract_i128(0b11110000, 124);
 }
 
 #[test]


### PR DESCRIPTION
This PR introduces `extract_i<N>` and `extract_u<N>` functions for signed integers. While I suspect the latter will be used primarily when working with bitfields, I do have a few usecases for both in a personal project of mine. It also just felt natural to have functions that work with the same underlying type as the `Int`, without having the user cast the value (which may trigger `clippy::cast_possible_wrap`).

That lead me to introduce `extract_i<N>` methods for unsigned integers as well, for consistency's sake. Luckily that's just a few extra lines with the macro I've added :)

Having a separate function for both signed and unsigned primitives does introduce quite a few functions for something that can be expressed with `extract_u8(my_i8 as u8)` as well though, so let me know if you'd rather just have one or the other.

(It might be easiest to review the tests commit-by-commit, the overall diff is a bit hard to read IMO)