### PR TITLE
Implement signed byte operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - New types for signed integers: `i1`, ..., `i127`. They have a similar API to unsigned integers, though a few
   features currently remain exclusive to unsigned integers:
     * Support for the following optional Cargo features: `step_trait`, `borsh` and `schemars`
-    * Byte operations (`to_ne_bytes`, ...)
     * Checked arithmetic functions (`checked_add`, ...)
     * Overflowing arithmetic functions (`overflowing_add`, ...)
 - Various new extract functions: `extract_i8`, `extract_i16`, ..., `extract_i128`. These are the same as the

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,6 +3,7 @@
 /// Copies LEN bytes from `from[FROM_OFFSET]` to `to[TO_OFFSET]`.
 ///
 /// Usable in const contexts and inlines for small arrays.
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[inline(always)]
 pub(crate) const fn const_byte_copy<
     const LEN: usize,
@@ -155,14 +156,14 @@ macro_rules! bytes_operation_impl {
             pub const fn to_le_bytes(&self) -> [u8; Self::BITS >> 3] {
                 let mut result = [0_u8; Self::BITS >> 3];
                 let be = self.value.to_le_bytes();
-                const_byte_copy::<{ Self::BITS >> 3 }, 0, 0>(&mut result, &be);
+                crate::common::const_byte_copy::<{ Self::BITS >> 3 }, 0, 0>(&mut result, &be);
                 result
             }
 
             pub const fn to_be_bytes(&self) -> [u8; Self::BITS >> 3] {
                 let mut result = [0_u8; Self::BITS >> 3];
                 let be = self.value.to_be_bytes();
-                const_byte_copy::<{ Self::BITS >> 3 }, 0, { Self::UNUSED_BITS >> 3 }>(
+                crate::common::const_byte_copy::<{ Self::BITS >> 3 }, 0, { Self::UNUSED_BITS >> 3 }>(
                     &mut result,
                     &be,
                 );
@@ -171,7 +172,7 @@ macro_rules! bytes_operation_impl {
 
             pub const fn from_le_bytes(from: [u8; Self::BITS >> 3]) -> Self {
                 let mut bytes = [0_u8; core::mem::size_of::<$base_data_type>()];
-                const_byte_copy::<{ Self::BITS >> 3 }, { Self::UNUSED_BITS >> 3 }, 0>(
+                crate::common::const_byte_copy::<{ Self::BITS >> 3 }, { Self::UNUSED_BITS >> 3 }, 0>(
                     &mut bytes, &from,
                 );
                 Self {
@@ -181,7 +182,7 @@ macro_rules! bytes_operation_impl {
 
             pub const fn from_be_bytes(from: [u8; Self::BITS >> 3]) -> Self {
                 let mut bytes = [0_u8; core::mem::size_of::<$base_data_type>()];
-                const_byte_copy::<{ Self::BITS >> 3 }, 0, 0>(&mut bytes, &from);
+                crate::common::const_byte_copy::<{ Self::BITS >> 3 }, 0, 0>(&mut bytes, &from);
                 Self {
                     value: <$base_data_type>::from_be_bytes(bytes) >> Self::UNUSED_BITS,
                 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -169,7 +169,7 @@ macro_rules! bytes_operation_impl {
             }
 
             pub const fn from_le_bytes(from: [u8; Self::BITS >> 3]) -> Self {
-                let mut bytes = [0_u8; size_of::<$base_data_type>()];
+                let mut bytes = [0_u8; core::mem::size_of::<$base_data_type>()];
                 const_byte_copy::<{ Self::BITS >> 3 }, { Self::UNUSED_BITS >> 3 }, 0>(
                     &mut bytes, &from,
                 );
@@ -179,7 +179,7 @@ macro_rules! bytes_operation_impl {
             }
 
             pub const fn from_be_bytes(from: [u8; Self::BITS >> 3]) -> Self {
-                let mut bytes = [0_u8; size_of::<$base_data_type>()];
+                let mut bytes = [0_u8; core::mem::size_of::<$base_data_type>()];
                 const_byte_copy::<{ Self::BITS >> 3 }, 0, 0>(&mut bytes, &from);
                 Self {
                     value: <$base_data_type>::from_be_bytes(bytes) >> Self::UNUSED_BITS,

--- a/src/common.rs
+++ b/src/common.rs
@@ -141,6 +141,7 @@ pub(crate) use impl_extract;
 
 macro_rules! bytes_operation_impl {
     ($target:ty, $base_data_type:ty) => {
+        #[cfg(not(feature = "const_convert_and_const_trait_impl"))]
         impl $target {
             /// Reverses the byte order of the integer.
             #[inline]

--- a/src/common.rs
+++ b/src/common.rs
@@ -119,3 +119,76 @@ macro_rules! impl_extract {
 }
 
 pub(crate) use impl_extract;
+
+macro_rules! common_bytes_operation_impl {
+    ($base_data_type:ty, $bits:expr) => {
+        /// Reverses the byte order of the integer.
+        #[inline]
+        pub const fn swap_bytes(&self) -> Self {
+            // swap_bytes() of the underlying type does most of the work. Then, we just need to shift
+            Self {
+                value: self.value.swap_bytes() >> Self::UNUSED_BITS,
+            }
+        }
+
+        #[inline]
+        pub const fn to_ne_bytes(&self) -> [u8; $bits >> 3] {
+            #[cfg(target_endian = "little")]
+            {
+                self.to_le_bytes()
+            }
+            #[cfg(target_endian = "big")]
+            {
+                self.to_be_bytes()
+            }
+        }
+
+        #[inline]
+        pub const fn from_ne_bytes(bytes: [u8; $bits >> 3]) -> Self {
+            #[cfg(target_endian = "little")]
+            {
+                Self::from_le_bytes(bytes)
+            }
+            #[cfg(target_endian = "big")]
+            {
+                Self::from_be_bytes(bytes)
+            }
+        }
+
+        #[inline]
+        pub const fn to_le(self) -> Self {
+            #[cfg(target_endian = "little")]
+            {
+                self
+            }
+            #[cfg(target_endian = "big")]
+            {
+                self.swap_bytes()
+            }
+        }
+
+        #[inline]
+        pub const fn to_be(self) -> Self {
+            #[cfg(target_endian = "little")]
+            {
+                self.swap_bytes()
+            }
+            #[cfg(target_endian = "big")]
+            {
+                self
+            }
+        }
+
+        #[inline]
+        pub const fn from_le(value: Self) -> Self {
+            value.to_le()
+        }
+
+        #[inline]
+        pub const fn from_be(value: Self) -> Self {
+            value.to_be()
+        }
+    };
+}
+
+pub(crate) use common_bytes_operation_impl;

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1,7 +1,5 @@
 use crate::{
-    common::{
-        common_bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract,
-    },
+    common::{bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract},
     TryNewError,
 };
 use core::{
@@ -1396,57 +1394,22 @@ where
     }
 }
 
-macro_rules! bytes_operation_impl {
-    ($base_data_type:ty, $bits:expr, [$($indices:expr),+]) => {
-        impl Int<$base_data_type, $bits>
-        {
-            pub const fn to_le_bytes(&self) -> [u8; $bits >> 3] {
-                let v = self.value();
-
-                [ $( (v >> ($indices << 3)) as u8, )+ ]
-            }
-
-            pub const fn from_le_bytes(from: [u8; $bits >> 3]) -> Self {
-                let value = { 0 $( | (from[$indices] as $base_data_type) << ($indices << 3))+ };
-                Self { value: (value << Self::UNUSED_BITS) >> Self::UNUSED_BITS }
-            }
-
-            pub const fn to_be_bytes(&self) -> [u8; $bits >> 3] {
-                 let v = self.value();
-
-                [ $( (v >> ($bits - 8 - ($indices << 3))) as u8, )+ ]
-            }
-
-            pub const fn from_be_bytes(from: [u8; $bits >> 3]) -> Self {
-                let value = { 0 $( | (from[$indices] as $base_data_type) << ($bits - 8 - ($indices << 3)))+ };
-                Self { value: (value << Self::UNUSED_BITS) >> Self::UNUSED_BITS }
-            }
-
-            common_bytes_operation_impl!($base_data_type, $bits);
-        }
-    };
-}
-
-bytes_operation_impl!(i32, 24, [0, 1, 2]);
-bytes_operation_impl!(i64, 24, [0, 1, 2]);
-bytes_operation_impl!(i128, 24, [0, 1, 2]);
-bytes_operation_impl!(i64, 40, [0, 1, 2, 3, 4]);
-bytes_operation_impl!(i128, 40, [0, 1, 2, 3, 4]);
-bytes_operation_impl!(i64, 48, [0, 1, 2, 3, 4, 5]);
-bytes_operation_impl!(i128, 48, [0, 1, 2, 3, 4, 5]);
-bytes_operation_impl!(i64, 56, [0, 1, 2, 3, 4, 5, 6]);
-bytes_operation_impl!(i128, 56, [0, 1, 2, 3, 4, 5, 6]);
-bytes_operation_impl!(i128, 72, [0, 1, 2, 3, 4, 5, 6, 7, 8]);
-bytes_operation_impl!(i128, 80, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-bytes_operation_impl!(i128, 88, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-bytes_operation_impl!(i128, 96, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-bytes_operation_impl!(i128, 104, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-bytes_operation_impl!(i128, 112, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-bytes_operation_impl!(
-    i128,
-    120,
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
-);
+bytes_operation_impl!(Int<i32, 24>, i32);
+bytes_operation_impl!(Int<i64, 24>, i64);
+bytes_operation_impl!(Int<i128, 24>, i128);
+bytes_operation_impl!(Int<i64, 40>, i64);
+bytes_operation_impl!(Int<i128, 40>, i128);
+bytes_operation_impl!(Int<i64, 48>, i64);
+bytes_operation_impl!(Int<i128, 48>, i128);
+bytes_operation_impl!(Int<i64, 56>, i64);
+bytes_operation_impl!(Int<i128, 56>, i128);
+bytes_operation_impl!(Int<i128, 72>, i128);
+bytes_operation_impl!(Int<i128, 80>, i128);
+bytes_operation_impl!(Int<i128, 88>, i128);
+bytes_operation_impl!(Int<i128, 96>, i128);
+bytes_operation_impl!(Int<i128, 104>, i128);
+bytes_operation_impl!(Int<i128, 112>, i128);
+bytes_operation_impl!(Int<i128, 120>, i128);
 
 // Conversions
 from_arbitrary_int_impl!(Int(i8), [i16, i32, i64, i128]);
@@ -1461,6 +1424,7 @@ from_native_impl!(Int(i32), [i8, i16, i32, i64, i128]);
 from_native_impl!(Int(i64), [i8, i16, i32, i64, i128]);
 from_native_impl!(Int(i128), [i8, i16, i32, i64, i128]);
 
+use crate::common::const_byte_copy;
 pub use aliases::*;
 
 #[allow(non_camel_case_types)]

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1424,7 +1424,6 @@ from_native_impl!(Int(i32), [i8, i16, i32, i64, i128]);
 from_native_impl!(Int(i64), [i8, i16, i32, i64, i128]);
 from_native_impl!(Int(i128), [i8, i16, i32, i64, i128]);
 
-use crate::common::const_byte_copy;
 pub use aliases::*;
 
 #[allow(non_camel_case_types)]

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    bytes_operation_impl, const_byte_copy, from_arbitrary_int_impl, from_native_impl, impl_extract,
+    bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract,
 };
 use crate::TryNewError;
 use core::fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, UpperHex};

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    common_bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract,
+    bytes_operation_impl, const_byte_copy, from_arbitrary_int_impl, from_native_impl, impl_extract,
 };
 use crate::TryNewError;
 use core::fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, UpperHex};
@@ -1695,57 +1695,22 @@ where
     }
 }
 
-macro_rules! bytes_operation_impl {
-    ($base_data_type:ty, $bits:expr, [$($indices:expr),+]) => {
-        impl UInt<$base_data_type, $bits>
-        {
-            pub const fn to_le_bytes(&self) -> [u8; $bits >> 3] {
-                let v = self.value();
-
-                [ $( (v >> ($indices << 3)) as u8, )+ ]
-            }
-
-            pub const fn from_le_bytes(from: [u8; $bits >> 3]) -> Self {
-                let value = { 0 $( | (from[$indices] as $base_data_type) << ($indices << 3))+ };
-                Self { value }
-            }
-
-            pub const fn to_be_bytes(&self) -> [u8; $bits >> 3] {
-                 let v = self.value();
-
-                [ $( (v >> ($bits - 8 - ($indices << 3))) as u8, )+ ]
-            }
-
-            pub const fn from_be_bytes(from: [u8; $bits >> 3]) -> Self {
-                let value = { 0 $( | (from[$indices] as $base_data_type) << ($bits - 8 - ($indices << 3)))+ };
-                Self { value }
-            }
-
-            common_bytes_operation_impl!($base_data_type, $bits);
-        }
-    };
-}
-
-bytes_operation_impl!(u32, 24, [0, 1, 2]);
-bytes_operation_impl!(u64, 24, [0, 1, 2]);
-bytes_operation_impl!(u128, 24, [0, 1, 2]);
-bytes_operation_impl!(u64, 40, [0, 1, 2, 3, 4]);
-bytes_operation_impl!(u128, 40, [0, 1, 2, 3, 4]);
-bytes_operation_impl!(u64, 48, [0, 1, 2, 3, 4, 5]);
-bytes_operation_impl!(u128, 48, [0, 1, 2, 3, 4, 5]);
-bytes_operation_impl!(u64, 56, [0, 1, 2, 3, 4, 5, 6]);
-bytes_operation_impl!(u128, 56, [0, 1, 2, 3, 4, 5, 6]);
-bytes_operation_impl!(u128, 72, [0, 1, 2, 3, 4, 5, 6, 7, 8]);
-bytes_operation_impl!(u128, 80, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-bytes_operation_impl!(u128, 88, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-bytes_operation_impl!(u128, 96, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-bytes_operation_impl!(u128, 104, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-bytes_operation_impl!(u128, 112, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-bytes_operation_impl!(
-    u128,
-    120,
-    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
-);
+bytes_operation_impl!(UInt<u32, 24>, u32);
+bytes_operation_impl!(UInt<u64, 24>, u64);
+bytes_operation_impl!(UInt<u128, 24>, u128);
+bytes_operation_impl!(UInt<u64, 40>, u64);
+bytes_operation_impl!(UInt<u128, 40>, u128);
+bytes_operation_impl!(UInt<u64, 48>, u64);
+bytes_operation_impl!(UInt<u128, 48>, u128);
+bytes_operation_impl!(UInt<u64, 56>, u64);
+bytes_operation_impl!(UInt<u128, 56>, u128);
+bytes_operation_impl!(UInt<u128, 72>, u128);
+bytes_operation_impl!(UInt<u128, 80>, u128);
+bytes_operation_impl!(UInt<u128, 88>, u128);
+bytes_operation_impl!(UInt<u128, 96>, u128);
+bytes_operation_impl!(UInt<u128, 104>, u128);
+bytes_operation_impl!(UInt<u128, 112>, u128);
+bytes_operation_impl!(UInt<u128, 120>, u128);
 
 // Conversions
 from_arbitrary_int_impl!(UInt(u8), [u16, u32, u64, u128]);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1849,6 +1849,16 @@ fn to_le_and_be_bytes_signed() {
         Int::<i128, 24>::new(0x12_34_56).to_le_bytes(),
         [0x56, 0x34, 0x12]
     );
+
+    assert_eq!(i24::new(0x12_34_56).to_be_bytes(), [0x12, 0x34, 0x56]);
+    assert_eq!(
+        i24::new(0xFF_F2_34_56u32 as i32).to_be_bytes(),
+        [0xF2, 0x34, 0x56]
+    );
+    assert_eq!(
+        Int::<i64, 24>::new(0xFF_FF_FF_FF_FF_F2_34_56u64 as i64).to_be_bytes(),
+        [0xF2, 0x34, 0x56]
+    );
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1526,7 +1526,7 @@ fn hash() {
 }
 
 #[test]
-fn swap_bytes() {
+fn swap_bytes_unsigned() {
     assert_eq!(u24::new(0x12_34_56).swap_bytes(), u24::new(0x56_34_12));
     assert_eq!(
         UInt::<u64, 24>::new(0x12_34_56).swap_bytes(),
@@ -1601,7 +1601,84 @@ fn swap_bytes() {
 }
 
 #[test]
-fn to_le_and_be_bytes() {
+fn swap_bytes_signed() {
+    // Signed numbers have to sign extended, so the following tests look less symmetrical than the
+    // unsigned tests
+    assert_eq!(i24::new(0x12_34_56).swap_bytes(), i24::new(0x56_34_12));
+    assert_eq!(
+        Int::<i64, 24>::new(0x12_34_56).swap_bytes(),
+        Int::<i64, 24>::new(0x56_34_12)
+    );
+    assert_eq!(
+        Int::<i128, 24>::new(0x12_34_56).swap_bytes(),
+        Int::<i128, 24>::new(0x56_34_12)
+    );
+
+    assert_eq!(
+        i40::new(0x12_34_56_78_9A).swap_bytes(),
+        i40::new(0xFF_FF_FF_9A_78_56_34_12u64 as i64)
+    );
+    assert_eq!(
+        Int::<i128, 40>::new(0x12_34_56_78_9A).swap_bytes(),
+        Int::<i128, 40>::new(0xFF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_9A_78_56_34_12u128 as i128)
+    );
+
+    assert_eq!(
+        i48::new(0x12_34_56_78_9A_BC).swap_bytes(),
+        i48::new(0xFF_FF_BC_9A_78_56_34_12u64 as i64)
+    );
+    assert_eq!(
+        Int::<i128, 48>::new(0x12_34_56_78_9A_BC).swap_bytes(),
+        Int::<i128, 48>::new(0xFF_FF_FF_FF_FF_FF_FF_FF_FF_FF_BC_9A_78_56_34_12u128 as i128)
+    );
+
+    assert_eq!(
+        i56::new(0x12_34_56_78_9A_BC_DE).swap_bytes(),
+        i56::new(0xFF_DE_BC_9A_78_56_34_12u64 as i64)
+    );
+    assert_eq!(
+        Int::<i128, 56>::new(0x12_34_56_78_9A_BC_DE).swap_bytes(),
+        Int::<i128, 56>::new(0xFF_FF_FF_FF_FF_FF_FF_FF_FF_DE_BC_9A_78_56_34_12u128 as i128)
+    );
+
+    assert_eq!(
+        i72::new(0x12_34_56_78_9A_BC_DE_FE_DC).swap_bytes(),
+        i72::new(0xFF_FF_FF_FF_FF_FF_FF_DC_FE_DE_BC_9A_78_56_34_12u128 as i128)
+    );
+
+    assert_eq!(
+        i80::new(0x12_34_56_78_9A_BC_DE_FE_DC_BA).swap_bytes(),
+        i80::new(0xFF_FF_FF_FF_FF_FF_BA_DC_FE_DE_BC_9A_78_56_34_12u128 as i128)
+    );
+
+    assert_eq!(
+        i88::new(0x12_34_56_78_9A_BC_DE_FE_DC_BA_98).swap_bytes(),
+        i88::new(0xFF_FF_FF_FF_FF_98_BA_DC_FE_DE_BC_9A_78_56_34_12u128 as i128)
+    );
+
+    assert_eq!(
+        i96::new(0x12_34_56_78_9A_BC_DE_FE_DC_BA_98_76).swap_bytes(),
+        i96::new(0x76_98_BA_DC_FE_DE_BC_9A_78_56_34_12)
+    );
+
+    assert_eq!(
+        i104::new(0x12_34_56_78_9A_BC_DE_FE_DC_BA_98_76_54).swap_bytes(),
+        i104::new(0x54_76_98_BA_DC_FE_DE_BC_9A_78_56_34_12)
+    );
+
+    assert_eq!(
+        i112::new(0x12_34_56_78_9A_BC_DE_FE_DC_BA_98_76_54_32).swap_bytes(),
+        i112::new(0x32_54_76_98_BA_DC_FE_DE_BC_9A_78_56_34_12)
+    );
+
+    assert_eq!(
+        i120::new(0x12_34_56_78_9A_BC_DE_FE_DC_BA_98_76_54_32_10).swap_bytes(),
+        i120::new(0x10_32_54_76_98_BA_DC_FE_DE_BC_9A_78_56_34_12)
+    );
+}
+
+#[test]
+fn to_le_and_be_bytes_unsigned() {
     assert_eq!(u24::new(0x12_34_56).to_le_bytes(), [0x56, 0x34, 0x12]);
     assert_eq!(
         UInt::<u64, 24>::new(0x12_34_56).to_le_bytes(),
@@ -1754,7 +1831,28 @@ fn to_le_and_be_bytes() {
 }
 
 #[test]
-fn from_le_and_be_bytes() {
+fn to_le_and_be_bytes_signed() {
+    assert_eq!(i24::new(0x12_34_56).to_le_bytes(), [0x56, 0x34, 0x12]);
+    assert_eq!(
+        i24::new(0xFF_F2_34_56u32 as i32).to_le_bytes(),
+        [0x56, 0x34, 0xF2]
+    );
+    assert_eq!(
+        Int::<i64, 24>::new(0x12_34_56).to_le_bytes(),
+        [0x56, 0x34, 0x12]
+    );
+    assert_eq!(
+        Int::<i64, 24>::new(0xFF_FF_FF_FF_FF_F2_34_56u64 as i64).to_le_bytes(),
+        [0x56, 0x34, 0xF2]
+    );
+    assert_eq!(
+        Int::<i128, 24>::new(0x12_34_56).to_le_bytes(),
+        [0x56, 0x34, 0x12]
+    );
+}
+
+#[test]
+fn from_le_and_be_bytes_unsigned() {
     assert_eq!(u24::from_le_bytes([0x56, 0x34, 0x12]), u24::new(0x12_34_56));
     assert_eq!(
         UInt::<u64, 24>::from_le_bytes([0x56, 0x34, 0x12]),
@@ -1919,16 +2017,89 @@ fn from_le_and_be_bytes() {
 }
 
 #[test]
+fn from_le_and_be_bytes_signed() {
+    assert_eq!(
+        i24::from_le_bytes([0x56, 0x34, 0xF2]),
+        i24::new(0xFF_F2_34_56u32 as i32)
+    );
+    assert_eq!(
+        Int::<i64, 24>::from_le_bytes([0x56, 0x34, 0xF2]),
+        Int::<i64, 24>::new(0xFF_FF_FF_FF_FF_F2_34_56u64 as i64)
+    );
+    assert_eq!(
+        Int::<i128, 24>::from_le_bytes([0x56, 0x34, 0xF2]),
+        Int::<i128, 24>::new(0xFF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_F2_34_56u128 as i128)
+    );
+
+    assert_eq!(
+        i24::from_be_bytes([0xF2, 0x34, 0x56]),
+        i24::new(0xFF_F2_34_56u32 as i32)
+    );
+    assert_eq!(
+        Int::<i64, 24>::from_be_bytes([0xF2, 0x34, 0x56]),
+        Int::<i64, 24>::new(0xFF_FF_FF_FF_FF_F2_34_56u64 as i64)
+    );
+    assert_eq!(
+        Int::<i128, 24>::from_be_bytes([0x12, 0x34, 0x56]),
+        Int::<i128, 24>::new(0x12_34_56)
+    );
+    assert_eq!(
+        Int::<i128, 24>::from_be_bytes([0xF2, 0x34, 0x56]),
+        Int::<i128, 24>::new(0xFF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_F2_34_56u128 as i128)
+    );
+
+    assert_eq!(
+        i120::from_le_bytes([
+            0x10, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34,
+            0x12
+        ]),
+        i120::new(0x12_34_56_78_9A_BC_DE_FE_DC_BA_98_76_54_32_10)
+    );
+
+    assert_eq!(
+        i120::from_le_bytes([
+            0x10, 0x32, 0x54, 0x76, 0x98, 0xBA, 0xDC, 0xFE, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34,
+            0xF2
+        ]),
+        i120::new(0xFF_F2_34_56_78_9A_BC_DE_FE_DC_BA_98_76_54_32_10u128 as i128)
+    );
+
+    assert_eq!(
+        i120::from_be_bytes([
+            0xF2, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32,
+            0x10
+        ]),
+        i120::new(0xFF_F2_34_56_78_9A_BC_DE_FE_DC_BA_98_76_54_32_10u128 as i128)
+    );
+}
+
+#[test]
 fn to_ne_bytes() {
     if cfg!(target_endian = "little") {
         assert_eq!(
             u40::new(0x12_34_56_78_9A).to_ne_bytes(),
             [0x9A, 0x78, 0x56, 0x34, 0x12]
         );
+        assert_eq!(
+            i40::new(0x12_34_56_78_9A).to_ne_bytes(),
+            [0x9A, 0x78, 0x56, 0x34, 0x12]
+        );
+        assert_eq!(
+            i40::new(0xFF_FF_FF_F2_34_56_78_9Au64 as i64).to_ne_bytes(),
+            [0x9A, 0x78, 0x56, 0x34, 0xF2]
+        );
     } else {
         assert_eq!(
             u40::new(0x12_34_56_78_9A).to_ne_bytes(),
             [0x12, 0x34, 0x56, 0x78, 0x9A]
+        );
+        assert_eq!(
+            i40::new(0x12_34_56_78_9A).to_ne_bytes(),
+            [0x12, 0x34, 0x56, 0x78, 0x9A]
+        );
+        assert_eq!(
+            i40::new(0xFF_FF_FF_F2_34_56_78_9Au64 as i64).to_ne_bytes(),
+            [0xF2, 0x34, 0x56, 0x78, 0x9A]
         );
     }
 }
@@ -1940,16 +2111,32 @@ fn from_ne_bytes() {
             u40::from_ne_bytes([0x9A, 0x78, 0x56, 0x34, 0x12]),
             u40::new(0x12_34_56_78_9A)
         );
+        assert_eq!(
+            i40::from_ne_bytes([0x9A, 0x78, 0x56, 0x34, 0x12]),
+            i40::new(0x12_34_56_78_9A)
+        );
+        assert_eq!(
+            i40::from_ne_bytes([0x12, 0x34, 0x56, 0x78, 0x9A]),
+            i40::new(0xFF_FF_FF_9A_78_56_34_12u64 as i64)
+        );
     } else {
         assert_eq!(
             u40::from_ne_bytes([0x12, 0x34, 0x56, 0x78, 0x9A]),
             u40::new(0x12_34_56_78_9A)
         );
+        assert_eq!(
+            i40::from_ne_bytes([0x12, 0x34, 0x56, 0x78, 0x9A]),
+            i40::new(0x12_34_56_78_9A)
+        );
+        assert_eq!(
+            i40::from_ne_bytes([0x9A, 0x78, 0x56, 0x34, 0x12]),
+            i40::new(0xFF_FF_FF_9A_78_56_34_12u64 as i64)
+        );
     }
 }
 
 #[test]
-fn simple_le_be() {
+fn simple_le_be_unsigned() {
     const REGULAR: u40 = u40::new(0x12_34_56_78_9A);
     const SWAPPED: u40 = u40::new(0x9A_78_56_34_12);
     if cfg!(target_endian = "little") {
@@ -1962,6 +2149,23 @@ fn simple_le_be() {
         assert_eq!(REGULAR.to_be(), REGULAR);
         assert_eq!(u40::from_le(REGULAR), SWAPPED);
         assert_eq!(u40::from_be(REGULAR), REGULAR);
+    }
+}
+
+#[test]
+fn simple_le_be_signed() {
+    const REGULAR: i40 = i40::new(0x12_34_56_78_9A);
+    const SWAPPED: i40 = i40::new(0xFF_FF_FF_9A_78_56_34_12u64 as i64);
+    if cfg!(target_endian = "little") {
+        assert_eq!(REGULAR.to_le(), REGULAR);
+        assert_eq!(REGULAR.to_be(), SWAPPED);
+        assert_eq!(i40::from_le(REGULAR), REGULAR);
+        assert_eq!(i40::from_be(REGULAR), SWAPPED);
+    } else {
+        assert_eq!(REGULAR.to_le(), SWAPPED);
+        assert_eq!(REGULAR.to_be(), REGULAR);
+        assert_eq!(i40::from_le(REGULAR), SWAPPED);
+        assert_eq!(i40::from_be(REGULAR), REGULAR);
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1525,6 +1525,7 @@ fn hash() {
     assert_eq!(None, hashmap.get(&u5::new(12)));
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn swap_bytes_unsigned() {
     assert_eq!(u24::new(0x12_34_56).swap_bytes(), u24::new(0x56_34_12));
@@ -1600,6 +1601,7 @@ fn swap_bytes_unsigned() {
     );
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn swap_bytes_signed() {
     // Signed numbers have to sign extended, so the following tests look less symmetrical than the
@@ -1677,6 +1679,7 @@ fn swap_bytes_signed() {
     );
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn to_le_and_be_bytes_unsigned() {
     assert_eq!(u24::new(0x12_34_56).to_le_bytes(), [0x56, 0x34, 0x12]);
@@ -1830,6 +1833,7 @@ fn to_le_and_be_bytes_unsigned() {
     );
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn to_le_and_be_bytes_signed() {
     assert_eq!(i24::new(0x12_34_56).to_le_bytes(), [0x56, 0x34, 0x12]);
@@ -1861,6 +1865,7 @@ fn to_le_and_be_bytes_signed() {
     );
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn from_le_and_be_bytes_unsigned() {
     assert_eq!(u24::from_le_bytes([0x56, 0x34, 0x12]), u24::new(0x12_34_56));
@@ -2026,6 +2031,7 @@ fn from_le_and_be_bytes_unsigned() {
     );
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn from_le_and_be_bytes_signed() {
     assert_eq!(
@@ -2083,6 +2089,7 @@ fn from_le_and_be_bytes_signed() {
     );
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn to_ne_bytes() {
     if cfg!(target_endian = "little") {
@@ -2114,6 +2121,7 @@ fn to_ne_bytes() {
     }
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn from_ne_bytes() {
     if cfg!(target_endian = "little") {
@@ -2145,6 +2153,7 @@ fn from_ne_bytes() {
     }
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn simple_le_be_unsigned() {
     const REGULAR: u40 = u40::new(0x12_34_56_78_9A);
@@ -2162,6 +2171,7 @@ fn simple_le_be_unsigned() {
     }
 }
 
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
 #[test]
 fn simple_le_be_signed() {
     const REGULAR: i40 = i40::new(0x12_34_56_78_9A);


### PR DESCRIPTION
Implements byte operations (`swap_bytes`, `to_le_bytes` and friends) on signed numbers for feature parity with unsigned numbers.

This moves the implementation to common, which isn't compatible with the old compiler used for const_convert_and_const_trait_impl, so with this feature enabled we're losing those functions. Maybe
that's a good indication that we should remove support for this at this point.