### PR TITLE
Implement overflowing arithmetic functions for signed integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - New types for signed integers: `i1`, ..., `i127`. They have a similar API to unsigned integers, though a few
   features currently remain exclusive to unsigned integers:
     * Support for the following optional Cargo features: `borsh` and `schemars`,
-    * Overflowing arithmetic functions (`overflowing_add`, ...).
 - The old Number trait is now replaced with three traits: UnsignedInteger (equivalent to the old Number), SignedInteger
   and Integer (which can be either signed or unsigned).
 - prelude: `use arbitrary-int::prelude::*` to get everything (except for the deprecated Number trait).
@@ -18,7 +17,6 @@
 ### Fixed
 
 - `leading_zeros` and `trailing_zeros` now report the correct number of bits when a value of `MIN` is passed.
-
 
 ## arbitrary-int 1.3.0
 

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -488,7 +488,7 @@ macro_rules! int_impl {
                 #[inline]
                 #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_add(self, rhs: Self) -> Self {
-                    let sum = self.value.wrapping_add(rhs.value);
+                    let sum = self.value().wrapping_add(rhs.value());
                     Self {
                         value: (sum << Self::UNUSED_BITS) >> Self::UNUSED_BITS,
                     }
@@ -509,7 +509,7 @@ macro_rules! int_impl {
                 #[inline]
                 #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_sub(self, rhs: Self) -> Self {
-                    let sum = self.value.wrapping_sub(rhs.value);
+                    let sum = self.value().wrapping_sub(rhs.value());
                     Self {
                         value: (sum << Self::UNUSED_BITS) >> Self::UNUSED_BITS,
                     }
@@ -530,7 +530,7 @@ macro_rules! int_impl {
                 #[inline]
                 #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_mul(self, rhs: Self) -> Self {
-                    let sum = self.value.wrapping_mul(rhs.value);
+                    let sum = self.value().wrapping_mul(rhs.value());
                     Self {
                         value: (sum << Self::UNUSED_BITS) >> Self::UNUSED_BITS,
                     }
@@ -560,7 +560,7 @@ macro_rules! int_impl {
                 #[inline]
                 #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn wrapping_div(self, rhs: Self) -> Self {
-                    let sum = self.value.wrapping_div(rhs.value);
+                    let sum = self.value().wrapping_div(rhs.value());
                     Self {
                         // Unlike the unsigned implementation we do need to account for overflow here,
                         // `Self::MIN / -1` is equal to `Self::MAX + 1`.
@@ -624,7 +624,7 @@ macro_rules! int_impl {
                         // the downside would be that on weird CPUs that don't do wrapping_shl by
                         // default release builds would get slightly worse. Using << should give
                         // good release performance everywere
-                        value: (self.value << shift_amount) >> Self::UNUSED_BITS,
+                        value: (self.value() << shift_amount) >> Self::UNUSED_BITS,
                     }
                 }
 
@@ -657,7 +657,7 @@ macro_rules! int_impl {
                     };
 
                     Self {
-                        value: (self.value >> shift_amount),
+                        value: (self.value() >> shift_amount),
                     }
                 }
 
@@ -681,12 +681,12 @@ macro_rules! int_impl {
                         // We are something like a Int::<i8; 8>, we can fallback to the base implementation.
                         // This is very unlikely to happen in practice, but checking allows us to use
                         // `wrapping_add` instead of `saturating_add` in the common case, which is faster.
-                        let value = self.value.saturating_add(rhs.value);
+                        let value = self.value().saturating_add(rhs.value());
                         Self { value }
                     } else {
                         // We're dealing with fewer bits than the underlying type (e.g. i7).
                         // That means the addition can never overflow the underlying type.
-                        let value = self.value.wrapping_add(rhs.value);
+                        let value = self.value().wrapping_add(rhs.value());
                         if value > Self::MAX.value {
                             Self::MAX
                         } else if value < Self::MIN.value {
@@ -717,12 +717,12 @@ macro_rules! int_impl {
                         // We are something like a Int::<i8; 8>, we can fallback to the base implementation.
                         // This is very unlikely to happen in practice, but checking allows us to use
                         // `wrapping_sub` instead of `saturating_sub` in the common case, which is faster.
-                        let value = self.value.saturating_sub(rhs.value);
+                        let value = self.value().saturating_sub(rhs.value());
                         Self { value }
                     } else {
                         // We're dealing with fewer bits than the underlying type (e.g. i7).
                         // That means the subtraction can never overflow the underlying type.
-                        let value = self.value.wrapping_sub(rhs.value);
+                        let value = self.value().wrapping_sub(rhs.value());
                         if value > Self::MAX.value {
                             Self::MAX
                         } else if value < Self::MIN.value {
@@ -752,10 +752,10 @@ macro_rules! int_impl {
                     let value = if (BITS << 1) <= (core::mem::size_of::<$type>() << 3) {
                         // We have half the bits (e.g. i4 * i4) of the base type, so we can't overflow the base type
                         // `wrapping_mul` likely provides the best performance on all cpus
-                        self.value.wrapping_mul(rhs.value)
+                        self.value().wrapping_mul(rhs.value())
                     } else {
                         // We have more than half the bits (e.g. i6 * i6)
-                        self.value.saturating_mul(rhs.value)
+                        self.value().saturating_mul(rhs.value())
                     };
 
                     if value > Self::MAX.value {
@@ -788,7 +788,7 @@ macro_rules! int_impl {
                 #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn saturating_div(self, rhs: Self) -> Self {
                     // As `Self::MIN / -1` is equal to `Self::MAX + 1` we always need to check for overflow.
-                    let value = self.value.saturating_div(rhs.value);
+                    let value = self.value().saturating_div(rhs.value());
 
                     if value > Self::MAX.value {
                         Self::MAX
@@ -843,7 +843,7 @@ macro_rules! int_impl {
                 pub const fn saturating_pow(self, exp: u32) -> Self {
                     // It might be possible to handwrite this to be slightly faster as both
                     // `saturating_pow` has to do a bounds-check and then we do second one.
-                    let value = self.value.saturating_pow(exp);
+                    let value = self.value().saturating_pow(exp);
 
                     if value > Self::MAX.value {
                         Self::MAX

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2924,7 +2924,7 @@ fn checked_shr_signed() {
 }
 
 #[test]
-fn overflowing_add() {
+fn overflowing_add_unsigned() {
     assert_eq!(
         u7::new(120).overflowing_add(u7::new(1)),
         (u7::new(121), false)
@@ -2952,7 +2952,55 @@ fn overflowing_add() {
 }
 
 #[test]
-fn overflowing_sub() {
+fn overflowing_add_signed() {
+    assert_eq!(
+        i7::new(60).overflowing_add(i7::new(1)),
+        (i7::new(61), false)
+    );
+
+    assert_eq!(
+        i7::new(60).overflowing_add(i7::new(-1)),
+        (i7::new(59), false)
+    );
+
+    assert_eq!(
+        i7::new(-60).overflowing_add(i7::new(4)),
+        (i7::new(-56), false)
+    );
+
+    assert_eq!(
+        i7::new(-60).overflowing_add(i7::new(-4)),
+        (i7::new(-64), false)
+    );
+
+    assert_eq!(
+        i7::new(60).overflowing_add(i7::new(3)),
+        (i7::new(63), false)
+    );
+
+    assert_eq!(
+        i7::new(60).overflowing_add(i7::new(10)),
+        (i7::new(-58), true)
+    );
+
+    assert_eq!(
+        i7::new(63).overflowing_add(i7::new(63)),
+        (i7::new(-2), true)
+    );
+
+    assert_eq!(
+        Int::<i8, 8>::new(120).overflowing_add(Int::<i8, 8>::new(7)),
+        (Int::<i8, 8>::new(127), false)
+    );
+
+    assert_eq!(
+        Int::<i8, 8>::new(120).overflowing_add(Int::<i8, 8>::new(10)),
+        (Int::<i8, 8>::new(-126), true)
+    );
+}
+
+#[test]
+fn overflowing_sub_unsigned() {
     assert_eq!(
         u7::new(120).overflowing_sub(u7::new(30)),
         (u7::new(90), false)
@@ -2973,7 +3021,60 @@ fn overflowing_sub() {
 }
 
 #[test]
-fn overflowing_mul() {
+fn overflowing_sub_signed() {
+    assert_eq!(
+        i7::new(60).overflowing_sub(i7::new(30)),
+        (i7::new(30), false)
+    );
+
+    assert_eq!(
+        i7::new(-30).overflowing_sub(i7::new(30)),
+        (i7::new(-60), false)
+    );
+
+    assert_eq!(
+        i7::new(-60).overflowing_sub(i7::new(-30)),
+        (i7::new(-30), false)
+    );
+
+    assert_eq!(
+        i7::new(60).overflowing_sub(i7::new(59)),
+        (i7::new(1), false)
+    );
+
+    assert_eq!(
+        i7::new(60).overflowing_sub(i7::new(60)),
+        (i7::new(0), false)
+    );
+
+    assert_eq!(
+        i7::new(60).overflowing_sub(i7::new(61)),
+        (i7::new(-1), false)
+    );
+
+    assert_eq!(
+        i7::new(-60).overflowing_sub(i7::new(5)),
+        (i7::new(63), true)
+    );
+
+    assert_eq!(
+        i7::new(-2).overflowing_sub(i7::new(63)),
+        (i7::new(63), true)
+    );
+
+    assert_eq!(
+        Int::<i8, 8>::new(120).overflowing_sub(Int::<i8, 8>::new(7)),
+        (Int::<i8, 8>::new(113), false)
+    );
+
+    assert_eq!(
+        Int::<i8, 8>::new(-120).overflowing_sub(Int::<i8, 8>::new(10)),
+        (Int::<i8, 8>::new(126), true)
+    );
+}
+
+#[test]
+fn overflowing_mul_unsigned() {
     // Fast-path: Only the arbitrary int is bounds checked
     assert_eq!(u4::new(5).overflowing_mul(u4::new(2)), (u4::new(10), false));
     assert_eq!(u4::new(5).overflowing_mul(u4::new(3)), (u4::new(15), false));
@@ -3001,7 +3102,36 @@ fn overflowing_mul() {
 }
 
 #[test]
-fn overflowing_div() {
+fn overflowing_mul_signed() {
+    // Fast-path: Only the arbitrary int is bounds checked
+    assert_eq!(i4::new(2).overflowing_mul(i4::new(1)), (i4::new(2), false));
+    assert_eq!(i4::new(2).overflowing_mul(i4::new(2)), (i4::new(4), false));
+    assert_eq!(i4::new(2).overflowing_mul(i4::new(3)), (i4::new(6), false));
+    assert_eq!(i4::new(2).overflowing_mul(i4::new(4)), (i4::new(-8), true));
+    assert_eq!(i4::new(2).overflowing_mul(i4::new(5)), (i4::new(-6), true));
+    assert_eq!(i4::new(2).overflowing_mul(i4::new(6)), (i4::new(-4), true));
+    assert_eq!(i4::new(2).overflowing_mul(i4::new(7)), (i4::new(-2), true));
+
+    // Slow-path (well, one more comparison)
+    assert_eq!(i6::new(5).overflowing_mul(i6::new(2)), (i6::new(10), false));
+    assert_eq!(i6::new(5).overflowing_mul(i6::new(3)), (i6::new(15), false));
+    assert_eq!(i6::new(5).overflowing_mul(i6::new(4)), (i6::new(20), false));
+    assert_eq!(i6::new(5).overflowing_mul(i6::new(5)), (i6::new(25), false));
+    assert_eq!(i6::new(5).overflowing_mul(i6::new(6)), (i6::new(30), false));
+    assert_eq!(i6::new(5).overflowing_mul(i6::new(7)), (i6::new(-29), true));
+    assert_eq!(
+        i6::new(30).overflowing_mul(i6::new(1)),
+        (i6::new(30), false)
+    );
+    assert_eq!(i6::new(30).overflowing_mul(i6::new(2)), (i6::new(-4), true));
+    assert_eq!(
+        i6::new(30).overflowing_mul(i6::new(10)),
+        (i6::new(-20), true)
+    );
+}
+
+#[test]
+fn overflowing_div_unsigned() {
     assert_eq!(u4::new(5).overflowing_div(u4::new(1)), (u4::new(5), false));
     assert_eq!(u4::new(5).overflowing_div(u4::new(2)), (u4::new(2), false));
     assert_eq!(u4::new(5).overflowing_div(u4::new(3)), (u4::new(1), false));
@@ -3009,14 +3139,56 @@ fn overflowing_div() {
     assert_eq!(u4::new(5).overflowing_div(u4::new(5)), (u4::new(1), false));
 }
 
+#[test]
+fn overflowing_div_signed() {
+    assert_eq!(i4::new(5).overflowing_div(i4::new(1)), (i4::new(5), false));
+    assert_eq!(i4::new(5).overflowing_div(i4::new(2)), (i4::new(2), false));
+    assert_eq!(i4::new(5).overflowing_div(i4::new(3)), (i4::new(1), false));
+    assert_eq!(i4::new(5).overflowing_div(i4::new(4)), (i4::new(1), false));
+    assert_eq!(i4::new(5).overflowing_div(i4::new(5)), (i4::new(1), false));
+    assert_eq!(
+        i4::new(5).overflowing_div(i4::new(-5)),
+        (i4::new(-1), false)
+    );
+    assert_eq!(i4::MIN.overflowing_div(i4::new(-1)), (i4::MIN, true));
+
+    assert_eq!(
+        Int::<i8, 8>::new(120).overflowing_div(Int::<i8, 8>::new(2)),
+        (Int::<i8, 8>::new(60), false)
+    );
+    assert_eq!(
+        Int::<i8, 8>::MIN.overflowing_div(Int::<i8, 8>::new(-1)),
+        (Int::<i8, 8>::MIN, true)
+    );
+}
+
 #[should_panic]
 #[test]
-fn overflowing_div_by_zero() {
+fn overflowing_div_by_zero_unsigned() {
     let _ = u4::new(5).overflowing_div(u4::new(0));
 }
 
+#[should_panic]
 #[test]
-fn overflowing_shl() {
+fn overflowing_div_by_zero_signed() {
+    let _ = i4::new(5).overflowing_div(i4::new(0));
+}
+
+#[test]
+fn overflowing_neg() {
+    assert_eq!(i17::new(0).overflowing_neg(), (i17::new(0), false));
+    assert_eq!(i17::new(-1).overflowing_neg(), (i17::new(1), false));
+    assert_eq!(i17::new(2).overflowing_neg(), (i17::new(-2), false));
+    assert_eq!(i17::new(-3).overflowing_neg(), (i17::new(3), false));
+    assert_eq!(i17::new(4).overflowing_neg(), (i17::new(-4), false));
+    assert_eq!(i17::new(-5).overflowing_neg(), (i17::new(5), false));
+
+    assert_eq!(i17::MAX.overflowing_neg(), (i17::MIN + i17::new(1), false));
+    assert_eq!(i17::MIN.overflowing_neg(), (i17::MIN, true));
+}
+
+#[test]
+fn overflowing_shl_unsigned() {
     assert_eq!(
         u7::new(0b010_1101).overflowing_shl(0),
         (u7::new(0b010_1101), false)
@@ -3045,10 +3217,52 @@ fn overflowing_shl() {
         u7::new(0b010_1101).overflowing_shl(15),
         (u7::new(0b101_1010), true)
     );
+
+    assert_eq!(
+        u14::new(0b010_1101).overflowing_shl(14),
+        (u14::new(0b010_1101), true)
+    );
 }
 
 #[test]
-fn overflowing_shr() {
+fn overflowing_shl_signed() {
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shl(0),
+        (i7::from_bits(0b010_1101), false)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shl(1),
+        (i7::from_bits(0b101_1010), false)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shl(6),
+        (i7::from_bits(0b100_0000), false)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shl(7),
+        (i7::from_bits(0b010_1101), true)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shl(8),
+        (i7::from_bits(0b101_1010), true)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shl(14),
+        (i7::from_bits(0b010_1101), true)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shl(15),
+        (i7::from_bits(0b101_1010), true)
+    );
+
+    assert_eq!(
+        i14::from_bits(0b010_1101).overflowing_shl(14),
+        (i14::from_bits(0b010_1101), true)
+    );
+}
+
+#[test]
+fn overflowing_shr_unsigned() {
     assert_eq!(
         u7::new(0b010_1101).overflowing_shr(0),
         (u7::new(0b010_1101), false)
@@ -3076,6 +3290,38 @@ fn overflowing_shr() {
     assert_eq!(
         u7::new(0b010_1101).overflowing_shr(15),
         (u7::new(0b001_0110), true)
+    );
+}
+
+#[test]
+fn overflowing_shr_signed() {
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shr(0),
+        (i7::from_bits(0b010_1101), false)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shr(1),
+        (i7::from_bits(0b001_0110), false)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shr(5),
+        (i7::from_bits(0b000_0001), false)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shr(7),
+        (i7::from_bits(0b010_1101), true)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shr(8),
+        (i7::from_bits(0b001_0110), true)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shr(14),
+        (i7::from_bits(0b010_1101), true)
+    );
+    assert_eq!(
+        i7::from_bits(0b010_1101).overflowing_shr(15),
+        (i7::from_bits(0b001_0110), true)
     );
 }
 


### PR DESCRIPTION
With these I was able to simplify the implementation of the `checked_*` and `wrapping_*` functions, since the `overflowing_*` methods provide (a superset of) equivalent functionality. This matches what the standard library does in a [few places](https://github.com/rust-lang/rust/blob/ed201574c5d6117fb4a491db545c96fa4289ea9c/library/core/src/num/int_macros.rs#L2046).

I also used the `self.value()` method instead of directly accessing the `self.value` field in a few places, since that might slightly improve performance if the `hint` feature is enabled (and shouldn't hurt if it isn't).