### PR TITLE
Implement `schemars` support for signed integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - New types for signed integers: `i1`, ..., `i127`. They have a similar API to unsigned integers, though a few
   features currently remain exclusive to unsigned integers:
-    * Support for the following optional Cargo features: `step_trait`, `borsh` and `schemars`
+    * Support for the following optional Cargo features: `step_trait` and `borsh`
     * Overflowing arithmetic functions (`overflowing_add`, ...)
 - Various new extract functions: `extract_i8`, `extract_i16`, ..., `extract_i128`. These are the same as the
   equivalent `extract_u<N>` functions, but work with signed integers instead.

--- a/src/common.rs
+++ b/src/common.rs
@@ -250,3 +250,35 @@ macro_rules! bytes_operation_impl {
 }
 
 pub(crate) use bytes_operation_impl;
+
+macro_rules! impl_schemars {
+    ($type:tt, $str_prefix:literal, $number_or_signed_number_trait:ident) => {
+        #[cfg(feature = "schemars")]
+        impl<T, const BITS: usize> schemars::JsonSchema for $type<T, BITS>
+        where
+            Self: $number_or_signed_number_trait,
+        {
+            fn schema_name() -> String {
+                [$str_prefix, &BITS.to_string()].concat()
+            }
+
+            fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+                use schemars::schema::{InstanceType, NumberValidation, Schema, SchemaObject};
+                let schema_object = SchemaObject {
+                    instance_type: Some(InstanceType::Integer.into()),
+                    format: Some(Self::schema_name()),
+                    number: Some(Box::new(NumberValidation {
+                        // Can be done with https://github.com/rust-lang/rfcs/pull/2484
+                        // minimum: Some(Self::MIN.value().try_into().ok().unwrap()),
+                        // maximum: Some(Self::MAX.value().try_into().ok().unwrap()),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                };
+                Schema::Object(schema_object)
+            }
+        }
+    };
+}
+
+pub(crate) use impl_schemars;

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1,5 +1,8 @@
 use crate::{
-    common::{bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract},
+    common::{
+        bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract,
+        impl_schemars,
+    },
     TryNewError,
 };
 use core::{
@@ -1709,6 +1712,9 @@ where
         }
     }
 }
+
+// Support for the `schemars` crate, if the feature is enabled.
+impl_schemars!(Int, "int", SignedNumber);
 
 bytes_operation_impl!(Int<i32, 24>, i32);
 bytes_operation_impl!(Int<i64, 24>, i64);

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract,
+    bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract, impl_schemars,
 };
 use crate::TryNewError;
 use core::fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, UpperHex};
@@ -20,9 +20,6 @@ use alloc::{collections::BTreeMap, string::ToString};
 
 #[cfg(all(feature = "borsh", feature = "std"))]
 use std::{collections::BTreeMap, string::ToString};
-
-#[cfg(feature = "schemars")]
-use schemars::JsonSchema;
 
 #[cfg_attr(feature = "const_convert_and_const_trait_impl", const_trait)]
 pub trait Number: Sized + Copy + Clone + PartialOrd + Ord + PartialEq + Eq {
@@ -1662,32 +1659,6 @@ where
     }
 }
 
-#[cfg(feature = "schemars")]
-impl<T, const BITS: usize> JsonSchema for UInt<T, BITS>
-where
-    Self: Number,
-{
-    fn schema_name() -> String {
-        ["uint", &BITS.to_string()].concat()
-    }
-
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        use schemars::schema::{NumberValidation, Schema, SchemaObject};
-        let schema_object = SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::Integer.into()),
-            format: Some(Self::schema_name()),
-            number: Some(Box::new(NumberValidation {
-                // can be done with https://github.com/rust-lang/rfcs/pull/2484
-                // minimum: Some(Self::MIN.value().try_into().ok().unwrap()),
-                // maximum: Some(Self::MAX.value().try_into().ok().unwrap()),
-                ..Default::default()
-            })),
-            ..Default::default()
-        };
-        Schema::Object(schema_object)
-    }
-}
-
 #[cfg(feature = "step_trait")]
 impl<T, const BITS: usize> Step for UInt<T, BITS>
 where
@@ -1781,6 +1752,9 @@ where
         Self::MAX
     }
 }
+
+// Support for the `schemars` crate, if the feature is enabled.
+impl_schemars!(UInt, "uint", Number);
 
 bytes_operation_impl!(UInt<u32, 24>, u32);
 bytes_operation_impl!(UInt<u64, 24>, u64);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3572,7 +3572,7 @@ mod borsh_tests {
 
 #[cfg(feature = "schemars")]
 #[test]
-fn schemars() {
+fn schemars_unsigned() {
     use schemars::schema_for;
     let mut u8 = schema_for!(u8);
     let u9 = schema_for!(u9);
@@ -3594,6 +3594,32 @@ fn schemars() {
     u8.schema.metadata = u9.schema.metadata.clone();
     u8.schema.number = u9.schema.number.clone();
     assert_eq!(u8, u9);
+}
+
+#[cfg(feature = "schemars")]
+#[test]
+fn schemars_signed() {
+    use schemars::schema_for;
+    let mut i8 = schema_for!(i8);
+    let i9 = schema_for!(i9);
+    assert_eq!(
+        i8.schema.format.clone().unwrap().replace("8", "9"),
+        i9.schema.format.clone().unwrap()
+    );
+    i8.schema.format = i9.schema.format.clone();
+    assert_eq!(
+        i8.schema
+            .metadata
+            .clone()
+            .unwrap()
+            .title
+            .unwrap()
+            .replace("8", "9"),
+        i9.schema.metadata.clone().unwrap().title.unwrap()
+    );
+    i8.schema.metadata = i9.schema.metadata.clone();
+    i8.schema.number = i9.schema.number.clone();
+    assert_eq!(i8, i9);
 }
 
 #[test]


### PR DESCRIPTION
This is another case where the implementation of `Int` and `UInt` could be shared entirely, which is always nice to see. With this only `num-traits` is left unimplemented for signed integers :)