### PR TITLE
Add various extra tests to CI

### DIFF
--- a/.github/workflows/check-clippy.yml
+++ b/.github/workflows/check-clippy.yml
@@ -1,0 +1,13 @@
+name: check clippy
+run-name: ${{ github.actor }}'s patch
+on: [push, pull_request]
+
+jobs:
+  check-clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+      - run: cargo clippy

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,14 @@
+name: check formatting
+run-name: ${{ github.actor }}'s patch
+on: [push, pull_request]
+
+jobs:
+  check-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - name: rustfmt
+        uses: actions-rust-lang/rustfmt@v1

--- a/.github/workflows/check-rustdoc.yml
+++ b/.github/workflows/check-rustdoc.yml
@@ -1,0 +1,14 @@
+# Rustdoc has a few lints that aren't included in `cargo check`: https://doc.rust-lang.org/rustdoc/lints.html
+name: check documentation
+run-name: ${{ github.actor }}'s patch
+on: [push, pull_request]
+
+jobs:
+  check-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"

--- a/.github/workflows/check-semantic-versioning.yml
+++ b/.github/workflows/check-semantic-versioning.yml
@@ -1,0 +1,17 @@
+name: check semantic versioning
+run-name: ${{ github.actor }}'s patch
+on: [push, pull_request]
+
+jobs:
+  check-semantic-versioning:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run cargo-semver-checks
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          # If we don't explicitly set which features to check `const_convert_and_const_trait_impl` will be used,
+          # which fails on modern compilers (which cargo-semver-checks requires).
+          feature-group: "only-explicit-features"
+          features: "std,step_trait,defmt,serde,borsh,schemars"

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1,5 +1,7 @@
 use crate::{
-    common::{bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract, impl_step},
+    common::{
+        bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract, impl_step,
+    },
     traits::{sealed::Sealed, Integer, SignedInteger},
     TryNewError,
 };

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
-use core::fmt::Debug;
 use crate::TryNewError;
+use core::fmt::Debug;
 
 pub(crate) mod sealed {
     /// Ensures that outside users can not implement the traits provided by this crate.
@@ -10,14 +10,16 @@ pub(crate) mod sealed {
 /// The base trait for integer numbers, either built-in (u8, i8, u16, i16, u32, i32, u64, i64,
 /// u128, i128) or arbitrary-int (u1, i1, u7, i7 etc.).
 #[cfg_attr(feature = "const_convert_and_const_trait_impl", const_trait)]
-pub trait Integer: Sized + Copy + Clone + PartialOrd + Ord + PartialEq + Eq + sealed::Sealed {
+pub trait Integer:
+    Sized + Copy + Clone + PartialOrd + Ord + PartialEq + Eq + sealed::Sealed
+{
     type UnderlyingType: Integer
-    + Debug
-    + TryFrom<u8>
-    + TryFrom<u16>
-    + TryFrom<u32>
-    + TryFrom<u64>
-    + TryFrom<u128>;
+        + Debug
+        + TryFrom<u8>
+        + TryFrom<u16>
+        + TryFrom<u32>
+        + TryFrom<u64>
+        + TryFrom<u128>;
 
     /// Number of bits that can fit in this type
     const BITS: usize;
@@ -87,4 +89,3 @@ pub trait SignedInteger: Integer {}
 /// arbitrary-int (u1, u7 etc.).
 #[cfg_attr(feature = "const_convert_and_const_trait_impl", const_trait)]
 pub trait UnsignedInteger: Integer {}
-

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1,7 +1,7 @@
 use crate::common::{
     bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract, impl_step,
 };
-use crate::traits::{Integer, UnsignedInteger, sealed::Sealed};
+use crate::traits::{sealed::Sealed, Integer, UnsignedInteger};
 use crate::TryNewError;
 use core::fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, UpperHex};
 #[cfg(feature = "num-traits")]

--- a/src/v1_number_compat.rs
+++ b/src/v1_number_compat.rs
@@ -1,5 +1,5 @@
-use crate::TryNewError;
 use crate::traits::{Integer, UnsignedInteger};
+use crate::TryNewError;
 use core::fmt::Debug;
 
 /// Compatibility with arbitrary-int 1.x, which didn't support signed integers.
@@ -10,7 +10,7 @@ use core::fmt::Debug;
 /// It is suggested to import via `use arbitrary_int::prelude::*` as `use arbitrary_int::*` will
 /// pull in this trait as well, which causes clashes with `Integer`.
 #[deprecated(
-    since = "2.0",
+    since = "2.0.0",
     note = "Use [`UnsignedInteger`] or [`Integer`] instead. Suggested to import via `use arbitrary_int::prelude::*`."
 )]
 pub trait Number: UnsignedInteger<UnderlyingType = <Self as Number>::UnderlyingType> {


### PR DESCRIPTION
This makes Github Actions test for a few extra things:
* Clippy lints. This actually catched an issue with the current codebase, which I've fixed.
* Rustfmt formatting. This had a few problems as well, but since a lot of code is inside macro repetitions it sadly won't catch everything. 
* Rustdoc warnings. There are a few rustdoc-specific warnings that `cargo check` doesn't catch, which makes it easy for them to slip under the radar. See https://github.com/danlehmann/arbitrary-int/pull/55/commits/c2824aa1c29ca2cb3365b6927e2313916594b647 for example.
* Semantic versioning violations using [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks). It can catch accidental breaking changes when we don't intend to make them. Since crates.io currently contains 1.3.0 but the repository 2.0.0, it recognizes that's a major version bump and won't throw any errors. I think it'll be useful after the release though.

I've locally tested that each of these fail when the repository has problems.