### PR TITLE
Implement `core::iter::{Sum,Product}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - Various new extract functions: `extract_i8`, `extract_i16`, ..., `extract_i128`. These are the same as the
   equivalent `extract_u<N>` functions, but work with signed integers instead.
 - Add `quickcheck` and `arbitrary` support
-- Implement `core::iter::Sum`: `[u4::new(1); 10].iter().sum::<u4>() == u4::new(10)`
+- Support `core::iter::Sum`: `[u7::new(1); 10].iter().sum::<u7>() == u7::new(10)`
+- Support `core::iter::Product`: `[i7::new(2); 4].iter().product::<i7>() == i7::new(16)`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Various new extract functions: `extract_i8`, `extract_i16`, ..., `extract_i128`. These are the same as the
   equivalent `extract_u<N>` functions, but work with signed integers instead.
 - Add `quickcheck` and `arbitrary` support
+- Implement `core::iter::Sum`: `[u4::new(1); 10].iter().sum::<u4>() == u4::new(10)`
 
 ### Fixed
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -251,6 +251,36 @@ macro_rules! bytes_operation_impl {
 
 pub(crate) use bytes_operation_impl;
 
+/// Implements [`core::iter::Sum`] and [`core::iter::Product`] for an integer type.
+macro_rules! impl_sum_product {
+    ($type:ident) => {
+        // This implements `Sum` for owned values, for example when using an iterator from a fixed-sized array.
+        impl<T, const BITS: usize> core::iter::Sum for $type<T, BITS>
+        where
+            Self: Integer + Default + core::ops::Add<Output = Self>,
+        {
+            #[inline]
+            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+                // Use `default()` to construct a value of zero.
+                iter.fold(Self::default(), |lhs, rhs| lhs + rhs)
+            }
+        }
+
+        // This implements `Sum` for borrowed values, for example when using an iterator from a slice.
+        impl<'a, T, const BITS: usize> core::iter::Sum<&'a Self> for $type<T, BITS>
+        where
+            Self: Integer + Default + core::ops::Add<Output = Self>,
+        {
+            #[inline]
+            fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+                iter.fold(Self::default(), |lhs, rhs| lhs + *rhs)
+            }
+        }
+    };
+}
+
+pub(crate) use impl_sum_product;
+
 macro_rules! impl_step {
     ($type:tt) => {
         #[cfg(feature = "step_trait")]

--- a/src/common.rs
+++ b/src/common.rs
@@ -253,7 +253,7 @@ pub(crate) use bytes_operation_impl;
 
 /// Implements [`core::iter::Sum`] and [`core::iter::Product`] for an integer type.
 macro_rules! impl_sum_product {
-    ($type:ident) => {
+    ($type:ident, $one:literal) => {
         // This implements `Sum` for owned values, for example when using an iterator from a fixed-sized array.
         impl<T, const BITS: usize> core::iter::Sum for $type<T, BITS>
         where
@@ -274,6 +274,30 @@ macro_rules! impl_sum_product {
             #[inline]
             fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
                 iter.fold(Self::default(), |lhs, rhs| lhs + *rhs)
+            }
+        }
+
+        // We need to use `Integer::from_()` to construct a value of one,
+        // which isn't available with `const_convert_and_const_trait_impl`.
+        #[cfg(not(feature = "const_convert_and_const_trait_impl"))]
+        impl<T, const BITS: usize> core::iter::Product for $type<T, BITS>
+        where
+            Self: Integer + core::ops::Mul<Output = Self>,
+        {
+            #[inline]
+            fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::from_($one), |lhs, rhs| lhs * rhs)
+            }
+        }
+
+        #[cfg(not(feature = "const_convert_and_const_trait_impl"))]
+        impl<'a, T, const BITS: usize> core::iter::Product<&'a Self> for $type<T, BITS>
+        where
+            Self: Integer + core::ops::Mul<Output = Self>,
+        {
+            #[inline]
+            fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+                iter.fold(Self::from_($one), |lhs, rhs| lhs * *rhs)
             }
         }
     };

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{
         bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract,
-        impl_num_traits, impl_step,
+        impl_num_traits, impl_step, impl_sum_product,
     },
     traits::{sealed::Sealed, Integer, SignedInteger},
     TryNewError,
@@ -1922,6 +1922,9 @@ where
         }
     }
 }
+
+// Implement `core::iter::Sum` and `core::iter::Product`.
+impl_sum_product!(Int);
 
 // Implement `core::iter::Step` (if the `step_trait` feature is enabled).
 impl_step!(Int);

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1924,7 +1924,7 @@ where
 }
 
 // Implement `core::iter::Sum` and `core::iter::Product`.
-impl_sum_product!(Int);
+impl_sum_product!(Int, 1_i8);
 
 // Implement `core::iter::Step` (if the `step_trait` feature is enabled).
 impl_step!(Int);

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1,6 +1,6 @@
 use crate::common::{
     bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract, impl_num_traits,
-    impl_step,
+    impl_step, impl_sum_product,
 };
 use crate::traits::{sealed::Sealed, Integer, UnsignedInteger};
 use crate::TryNewError;
@@ -1804,6 +1804,9 @@ where
         Schema::Object(schema_object)
     }
 }
+
+// Implement `core::iter::Sum` and `core::iter::Product`.
+impl_sum_product!(UInt);
 
 // Implement support for the `num-traits` crate, if the feature is enabled.
 impl_num_traits!(UInt, u8, |value| value & Self::MASK);

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1806,7 +1806,7 @@ where
 }
 
 // Implement `core::iter::Sum` and `core::iter::Product`.
-impl_sum_product!(UInt);
+impl_sum_product!(UInt, 1_u8);
 
 // Implement support for the `num-traits` crate, if the feature is enabled.
 impl_num_traits!(UInt, u8, |value| value & Self::MASK);

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,0 +1,97 @@
+use arbitrary_int::prelude::*;
+
+fn test_sum<'a, T, I>(iter: I, expected: T)
+where
+    T: core::iter::Sum<T> + core::iter::Sum<&'a T> + std::fmt::Debug + Copy + PartialEq + 'a,
+    I: IntoIterator<Item = &'a T> + Clone,
+{
+    // Test with an iterator yielding references
+    assert_eq!(iter.clone().into_iter().sum::<T>(), expected);
+    // Test with an iterator yielding owned values
+    assert_eq!(iter.into_iter().copied().sum::<T>(), expected);
+}
+
+#[test]
+pub fn sum_unsigned() {
+    test_sum(&[u7::new(0); 4], u7::new(0));
+    test_sum(&[u7::new(1); 4], u7::new(4));
+    test_sum(&[u7::new(2); 4], u7::new(8));
+    test_sum(&[u7::new(4); 4], u7::new(16));
+    test_sum(&[u7::new(1); 127], u7::new(127));
+
+    test_sum(
+        &[u7::new(1), u7::new(2), u7::new(3), u7::new(4)],
+        u7::new(10),
+    );
+}
+
+#[test]
+pub fn sum_signed() {
+    test_sum(&[i7::new(0); 4], i7::new(0));
+
+    test_sum(&[i7::new(1); 4], i7::new(4));
+    test_sum(&[i7::new(-1); 4], i7::new(-4));
+
+    test_sum(&[i7::new(2); 4], i7::new(8));
+    test_sum(&[i7::new(-2); 4], i7::new(-8));
+
+    test_sum(&[i7::new(4); 4], i7::new(16));
+    test_sum(&[i7::new(-4); 4], i7::new(-16));
+
+    test_sum(&[i7::new(1); 63], i7::new(63));
+    test_sum(&[i7::new(-1); 64], i7::new(-64));
+
+    test_sum(
+        &[i7::new(1), i7::new(2), i7::new(3), i7::new(4)],
+        i7::new(10),
+    );
+
+    test_sum(
+        &[i7::new(-1), i7::new(-2), i7::new(-3), i7::new(-4)],
+        i7::new(-10),
+    );
+
+    test_sum(
+        &[i7::new(1), i7::new(-2), i7::new(3), i7::new(-4)],
+        i7::new(-2),
+    );
+}
+
+#[cfg(not(debug_assertions))]
+#[test]
+pub fn sum_overflow_wraps_unsigned() {
+    test_sum(&[u7::new(1); 128], u7::new(0));
+    test_sum(&[u7::new(8); 16], u7::new(0));
+    test_sum(&[u7::new(9); 16], u7::new(16));
+}
+
+#[cfg(not(debug_assertions))]
+#[test]
+pub fn sum_overflow_wraps_signed() {
+    test_sum(&[i7::new(1); 64], i7::new(-64));
+    test_sum(&[i7::new(-1); 65], i7::new(63));
+
+    test_sum(&[i7::new(8); 8], i7::new(-64));
+    test_sum(&[i7::new(-8); 9], i7::new(56));
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic]
+pub fn sum_overflow_panic_unsigned() {
+    let _ = [u7::new(1); 128].iter().sum::<u7>();
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic]
+pub fn sum_overflow_upper_panic_signed() {
+    let _ = [i7::new(1); 64].iter().sum::<i7>();
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic]
+pub fn sum_overflow_lower_panic_signed() {
+    let _ = [i7::new(-1); 65].iter().sum::<i7>();
+}

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,8 +1,9 @@
 use arbitrary_int::prelude::*;
+use std::{fmt, iter::Sum};
 
 fn test_sum<'a, T, I>(iter: I, expected: T)
 where
-    T: core::iter::Sum<T> + core::iter::Sum<&'a T> + std::fmt::Debug + Copy + PartialEq + 'a,
+    T: Sum<T> + Sum<&'a T> + fmt::Debug + Copy + PartialEq + 'a,
     I: IntoIterator<Item = &'a T> + Clone,
 {
     // Test with an iterator yielding references
@@ -94,4 +95,89 @@ pub fn sum_overflow_upper_panic_signed() {
 #[should_panic]
 pub fn sum_overflow_lower_panic_signed() {
     let _ = [i7::new(-1); 65].iter().sum::<i7>();
+}
+
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
+fn test_product<'a, T, I>(iter: I, expected: T)
+where
+    T: std::iter::Product<T> + std::iter::Product<&'a T> + fmt::Debug + Copy + PartialEq + 'a,
+    I: IntoIterator<Item = &'a T> + Clone,
+{
+    // Test with an iterator yielding references
+    assert_eq!(iter.clone().into_iter().product::<T>(), expected);
+    // Test with an iterator yielding owned values
+    assert_eq!(iter.into_iter().copied().product::<T>(), expected);
+}
+
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
+#[test]
+pub fn product_unsigned() {
+    test_product(&[u7::new(0); 4], u7::new(0));
+    test_product(&[u7::new(1); 4], u7::new(1));
+    test_product(&[u7::new(2); 4], u7::new(16));
+    test_product(&[u7::new(4); 3], u7::new(64));
+    test_product(
+        &[u7::new(4), u7::new(4), u7::new(3), u7::new(2)],
+        u7::new(96),
+    );
+}
+
+#[cfg(not(feature = "const_convert_and_const_trait_impl"))]
+#[test]
+pub fn product_signed() {
+    test_product(&[i7::new(0); 4], i7::new(0));
+
+    test_product(&[i7::new(1); 4], i7::new(1));
+    test_product(&[i7::new(-1); 4], i7::new(1));
+    test_product(&[i7::new(-1); 3], i7::new(-1));
+
+    test_product(&[i7::new(2); 4], i7::new(16));
+    test_product(&[i7::new(-2); 4], i7::new(16));
+    test_product(&[i7::new(-2); 3], i7::new(-8));
+
+    test_product(&[i7::new(4), i7::new(4), i7::new(3)], i7::new(48));
+}
+
+#[cfg(all(
+    not(debug_assertions),
+    not(feature = "const_convert_and_const_trait_impl")
+))]
+#[test]
+pub fn product_overflow_wraps_unsigned() {
+    test_product(&[u7::new(2); 7], u7::new(0));
+    test_product(&[u7::new(3); 5], u7::new(115));
+}
+
+#[cfg(all(
+    not(debug_assertions),
+    not(feature = "const_convert_and_const_trait_impl")
+))]
+#[test]
+pub fn product_overflow_wraps_signed() {
+    test_product(&[i7::new(2); 6], i7::new(-64));
+    test_product(&[i7::new(-2); 8], i7::new(0));
+
+    test_product(&[i7::new(3); 4], i7::new(-47));
+    test_product(&[i7::new(-3); 13], i7::new(45));
+}
+
+#[cfg(all(debug_assertions, not(feature = "const_convert_and_const_trait_impl")))]
+#[test]
+#[should_panic]
+pub fn product_overflow_panic_unsigned() {
+    let _ = [u7::new(2); 8].iter().product::<u7>();
+}
+
+#[cfg(all(debug_assertions, not(feature = "const_convert_and_const_trait_impl")))]
+#[test]
+#[should_panic]
+pub fn product_overflow_upper_panic_signed() {
+    let _ = [i7::new(2); 6].iter().product::<i7>();
+}
+
+#[cfg(all(debug_assertions, not(feature = "const_convert_and_const_trait_impl")))]
+#[test]
+#[should_panic]
+pub fn product_overflow_lower_panic_signed() {
+    let _ = [i7::new(-2); 6].iter().product::<i7>();
 }


### PR DESCRIPTION
I noticed these two were missing when working with an iterator which yields `UInt`s. 