### PR TITLE
Implement bytemuck traits for Int/UInt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ borsh = ["dep:borsh"]
 
 schemars = ["dep:schemars", "std"]
 
+# Implement traits for bytemuck
+bytemuck = ["dep:bytemuck"]
+
 # Provide a soundness promise to the compiler that the underlying value is always within range.
 # This optimizes e.g. indexing range checks when passed in an API.
 # The downside of this feature is that it involves an unsafe call to `core::hint::assert_unchecked` during `value()`.
@@ -47,6 +50,7 @@ defmt = { version = "0.3.8", optional = true }
 serde = { version = "1.0", optional = true, default-features = false }
 borsh = { version = "1.5.1", optional = true, features = ["unstable__schema"], default-features = false }
 schemars = { version = "0.8.21", optional = true, features = ["derive"], default-features = false }
+bytemuck = {  version = "1", optional = true, default-features = false}
 
 arbitrary = { version = "1", optional = true, default-features = false }
 quickcheck = { version = "1", optional = true, default-features = false }


### PR DESCRIPTION
Requires documenting some guarantees about the in-memory representation.
