### PR TITLE
Add bin-proto support

### DIFF
--- a/.github/workflows/test-bin-proto.yml
+++ b/.github/workflows/test-bin-proto.yml
@@ -1,0 +1,15 @@
+name: test bin-proto
+run-name: ${{ github.actor }}'s patch
+on: [push, pull_request]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: true
+          toolchain: nightly
+      - run: |
+          cargo test --no-default-features --features=bin-proto
+          cargo test --no-default-features --features=bin-proto,std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ schemars = ["dep:schemars", "std"]
 # Implement traits for bytemuck
 bytemuck = ["dep:bytemuck"]
 
+# Implement traits for bin-proto
+bin-proto = ["dep:bin-proto"]
+
 # Provide a soundness promise to the compiler that the underlying value is always within range.
 # This optimizes e.g. indexing range checks when passed in an API.
 # The downside of this feature is that it involves an unsafe call to `core::hint::assert_unchecked` during `value()`.
@@ -48,6 +51,7 @@ serde = { version = "1.0", optional = true, default-features = false }
 borsh = { version = "1.5.1", optional = true, features = ["unstable__schema"], default-features = false }
 schemars = { version = "0.8.21", optional = true, features = ["derive"], default-features = false }
 bytemuck = { version = "1", optional = true, default-features = false }
+bin-proto = { version = "0.12.2", optional = true, default-features = false }
 
 arbitrary = { version = "1", optional = true, default-features = false }
 quickcheck = { version = "1", optional = true, default-features = false }

--- a/src/common.rs
+++ b/src/common.rs
@@ -567,3 +567,58 @@ macro_rules! impl_bytemuck_full {
 
 pub(crate) use impl_bytemuck_basic;
 pub(crate) use impl_bytemuck_full;
+
+// [`bin_proto::Bits`] has a [`u32`] constant, whereas `$type<T, $bits>` has a [`usize`] constant.
+// These cannot be cast in a const context, meaning that we cannot implement the traits for a
+// generic bit width.
+macro_rules! impl_bin_proto {
+    ($type:tt, $trait:ident) => {
+        impl_bin_proto!($type, $trait, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128);
+    };
+    ($type:tt, $trait:ident, $($bits:literal),+) => {
+        $(
+            #[cfg(feature = "bin-proto")]
+            impl<T: BuiltinInteger + $trait, Ctx> bin_proto::BitEncode<Ctx> for $type<T, $bits>
+            where
+                Self: Integer,
+                <Self as Integer>::UnderlyingType: bin_proto::BitEncode<Ctx, bin_proto::Bits<$bits>>,
+            {
+                fn encode<W, E>(&self, write: &mut W, ctx: &mut Ctx, (): ()) -> bin_proto::Result<()>
+                where
+                    W: bin_proto::BitWrite,
+                    E: bin_proto::Endianness,
+                {
+                    bin_proto::BitEncode::encode::<_, E>(
+                        &Integer::value(*self),
+                        write,
+                        ctx,
+                        bin_proto::Bits::<$bits>,
+                    )
+                }
+            }
+
+            #[cfg(feature = "bin-proto")]
+            impl<T: BuiltinInteger + $trait, Ctx> bin_proto::BitDecode<Ctx>
+                for $type<T, $bits>
+            where
+                Self: Integer,
+                <Self as Integer>::UnderlyingType: bin_proto::BitDecode<Ctx, bin_proto::Bits<$bits>>,
+            {
+                fn decode<R, E>(read: &mut R, ctx: &mut Ctx, (): ()) -> bin_proto::Result<Self>
+                where
+                    R: bin_proto::BitRead,
+                    E: bin_proto::Endianness,
+                {
+                    Ok(Self::new(
+                        <<Self as Integer>::UnderlyingType as bin_proto::BitDecode<_, _>>::decode::<
+                            _,
+                            E,
+                        >(read, ctx, bin_proto::Bits::<$bits>)?,
+                    ))
+                }
+            }
+        )+
+    };
+}
+
+pub(crate) use impl_bin_proto;

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{
-        bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_extract,
-        impl_num_traits, impl_schemars, impl_step, impl_sum_product,
+        bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_bin_proto,
+        impl_extract, impl_num_traits, impl_schemars, impl_step, impl_sum_product,
     },
     traits::{sealed::Sealed, BuiltinInteger, Integer, SignedInteger},
     TryNewError,
@@ -1852,6 +1852,8 @@ where
 }
 
 impl_borsh!(Int, "i", SignedInteger);
+
+impl_bin_proto!(Int, SignedInteger);
 
 // Serde's invalid_value error (https://rust-lang.github.io/hashbrown/serde/de/trait.Error.html#method.invalid_value)
 // takes an Unexpected (https://rust-lang.github.io/hashbrown/serde/de/enum.Unexpected.html) which only accepts a 64 bit

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_borsh,
+    bytes_operation_impl, from_arbitrary_int_impl, from_native_impl, impl_bin_proto, impl_borsh,
     impl_bytemuck_full, impl_extract, impl_num_traits, impl_schemars, impl_step, impl_sum_product,
 };
 use crate::traits::{sealed::Sealed, BuiltinInteger, Integer, UnsignedInteger};
@@ -1581,6 +1581,8 @@ where
 }
 
 impl_borsh!(UInt, "u", UnsignedInteger);
+
+impl_bin_proto!(UInt, UnsignedInteger);
 
 #[cfg(feature = "serde")]
 impl<T: BuiltinInteger + UnsignedInteger, const BITS: usize> serde::Serialize for UInt<T, BITS>

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4202,6 +4202,170 @@ mod bytemuck {
     }
 }
 
+#[cfg(feature = "bin-proto")]
+mod bin_proto_tests {
+    use bin_proto::{bitstream_io::BitsWritten, BitCodec, LittleEndian};
+
+    use super::*;
+
+    #[track_caller]
+    fn test_roundtrip<T>(input: T, expected_buffer: &[u8])
+    where
+        T: Integer + BitCodec,
+    {
+        let mut data = [0u8; 16];
+        let mut counter = BitsWritten::<u64>::new();
+        let n_bytes = input
+            .encode_bytes_buf(LittleEndian, &mut data)
+            .unwrap()
+            .try_into()
+            .unwrap();
+        input
+            .encode::<_, LittleEndian>(&mut counter, &mut (), ())
+            .unwrap();
+        assert_eq!(T::BITS, counter.written().try_into().unwrap());
+        assert_eq!(expected_buffer, &data[0..n_bytes])
+    }
+
+    #[test]
+    fn test_encode_decode() {
+        // Run against plain u64/i64 first (not an arbitrary_int)
+        test_roundtrip(
+            0x12345678_9ABCDEF0u64,
+            &[0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12],
+        );
+        test_roundtrip(-100i32, &[0x9C, 0xFF, 0xFF, 0xFF]);
+        test_roundtrip(i31::new(-100), &[0x9C, 0xFF, 0xFF, 0x7F]);
+
+        // Now try various arbitrary ints
+        test_roundtrip(u1::new(0b0), &[0]);
+        test_roundtrip(u1::new(0b1), &[1]);
+        test_roundtrip(i1::new(0), &[0]);
+        test_roundtrip(i1::new(-1), &[1]);
+        test_roundtrip(u6::new(0b101101), &[0b101101]);
+        test_roundtrip(i6::from_bits(0b101101), &[0b101101]);
+        test_roundtrip(u14::new(0b110101_11001101), &[0b11001101, 0b110101]);
+        test_roundtrip(i14::from_bits(0b110101_11001101), &[0b11001101, 0b110101]);
+        test_roundtrip(
+            u72::new(0x36_01234567_89ABCDEF),
+            &[0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01, 0x36],
+        );
+        test_roundtrip(
+            i72::from_bits(0x36_01234567_89ABCDEF),
+            &[0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01, 0x36],
+        );
+
+        test_roundtrip(u24::MAX, &u24::MAX.to_le_bytes());
+        test_roundtrip(i24::MAX, &i24::MAX.to_le_bytes());
+
+        test_roundtrip(u24::MIN, &u24::MIN.to_le_bytes());
+        test_roundtrip(i24::MIN, &i24::MIN.to_le_bytes());
+
+        test_roundtrip(u24::new(0xAB_CD_EF), &u24::new(0xAB_CD_EF).to_le_bytes());
+        test_roundtrip(
+            i24::from_bits(0xAB_CD_EF),
+            &i24::from_bits(0xAB_CD_EF).to_le_bytes(),
+        );
+
+        test_roundtrip(u24::new(0x12_34_56), &u24::new(0x12_34_56).to_le_bytes());
+        test_roundtrip(
+            i24::from_bits(0x12_34_56),
+            &i24::from_bits(0x12_34_56).to_le_bytes(),
+        );
+
+        // Pick a byte boundary (80; test one below and one above to ensure we get the right number
+        // of bytes)
+        test_roundtrip(
+            u79::MAX,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+        );
+        test_roundtrip(
+            i79::new(-1),
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+        );
+        test_roundtrip(
+            u80::MAX,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
+        );
+        test_roundtrip(
+            i80::new(-1),
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
+        );
+        test_roundtrip(
+            u81::MAX,
+            &[
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01,
+            ],
+        );
+        test_roundtrip(
+            i81::new(-1),
+            &[
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01,
+            ],
+        );
+
+        // Test MIN/MAX for signed integers
+        test_roundtrip(
+            i79::MAX,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x3F],
+        );
+        test_roundtrip(
+            i80::MAX,
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F],
+        );
+        test_roundtrip(
+            i81::MAX,
+            &[
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0,
+            ],
+        );
+
+        test_roundtrip(
+            i79::MIN,
+            &[0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x40],
+        );
+        test_roundtrip(
+            i80::MIN,
+            &[0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80],
+        );
+        test_roundtrip(
+            i81::MIN,
+            &[0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 1],
+        );
+
+        // Test actual u128 and arbitrary u128 (which is a legal one, though not predefined)
+        test_roundtrip(
+            u128::MAX,
+            &[
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF,
+            ],
+        );
+        test_roundtrip(
+            UInt::<u128, 128>::MAX,
+            &[
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF,
+            ],
+        );
+        // Test actual i128 and arbitrary i128 (which is a legal one, though not predefined)
+        test_roundtrip(
+            i128::new(-1),
+            &[
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF,
+            ],
+        );
+        test_roundtrip(
+            Int::<i128, 128>::new(-1),
+            &[
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF,
+            ],
+        );
+    }
+}
+
 #[test]
 fn new_and_as_specific_types() {
     let a = u6::new(42);


### PR DESCRIPTION
At work we're encoding/decoding types from arbitrary-int using the bin-proto crate. It would be useful to add support for this to arbitrary-int, so we don't have to maintain a fork.

But I also understand that this is additional maintenance burden (however small), so if that's an issue, we'll stick with the fork approach.