### PR TITLE
Bug fix on unsigned-to-signed conversions!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 - Removed compatibility for `const_convert_and_const_trait_impl`, which required an ancient nightly compiler.
 - Implement `SaturatingAdd` and `SaturatingSub` traits from `num-traits` for `Uint` and `Int`.
+
+### Fixed
+
 - Fixed incorrect behavior in conversions between signed and unsigned integers of equal bit-widths.
 
 ## arbitrary-int 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Removed compatibility for `const_convert_and_const_trait_impl`, which required an ancient nightly compiler.
 - Implement `SaturatingAdd` and `SaturatingSub` traits from `num-traits` for `Uint` and `Int`.
+- Fixed incorrect behavior in conversions between signed and unsigned integers of equal bit-widths.
 
 ## arbitrary-int 2.0.0
 

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -221,7 +221,9 @@ macro_rules! int_impl_num {
                 }
 
                 fn masked_new<T: Integer>(value: T) -> Self {
-                    if Self::BITS < T::BITS {
+                    // If the source type is wider, we need to mask and sign-extend. If the source
+                    // type is the same width but unsigned, we also need to sign-extend!
+                    if Self::BITS < T::BITS || (Self::BITS == T::BITS && T::MIN == T::ZERO) {
                         let value = (value.as_::<Self::UnderlyingType>() << Self::UNUSED_BITS) >> Self::UNUSED_BITS;
                         Self { value: Self::UnderlyingType::masked_new(value) }
                     } else {

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -214,7 +214,10 @@ macro_rules! uint_impl_num {
                 }
 
                 fn masked_new<T: Integer>(value: T) -> Self {
-                    if Self::BITS < T::BITS {
+                    // If the source type is wider, we need to mask. If the source type is the same
+                    // width but unsigned, we also need to mask, to ensure that we erase the padded
+                    // sign bits! (that is, negative integers are padded with ones on the left)
+                    if Self::BITS < T::BITS || (T::BITS == Self::BITS && T::MIN < T::ZERO) {
                         Self { value: Self::UnderlyingType::masked_new(value.as_::<Self::UnderlyingType>() & Self::MASK) }
                     } else {
                         Self { value: Self::UnderlyingType::masked_new(value) }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4411,6 +4411,6 @@ pub fn is_positive() {
 
 #[test]
 fn as_is_in_range() {
-    assert!(u4::new(10).as_::<i4>() <= i4::MAX);
-    assert!(u4::new(10).as_::<i4>() >= i4::MIN);
+    assert_eq!(u4::new(10).as_::<i4>().value(), -6);
+    assert_eq!(i4::new(-5).as_::<u4>().value(), 11);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4408,3 +4408,9 @@ pub fn is_positive() {
     assert!(!i4::MIN.is_positive());
     assert!(i4::MAX.is_positive());
 }
+
+#[test]
+fn as_is_in_range() {
+    assert!(u4::new(10).as_::<i4>() <= i4::MAX);
+    assert!(u4::new(10).as_::<i4>() >= i4::MIN);
+}


### PR DESCRIPTION
Introduce a bug fix on unsigned-to-signed conversions. Adds a test to explain the bug and avoid regression.
Tested only on the specific test case added, but as with the rest of the code base, I didn't see a point to check on other bit-widths.

I hope this PR finds you well!