### PR TITLE
Add changelog for bin-proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.1
+
+### Added
+
+- Added optional `bin-proto` support. Enable using the `bin-proto` feature (thanks wojciech-graj)
+
 ## 2.1.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbitrary-int"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Daniel Lehmann <danlehmannmuc@gmail.com>"]


### PR DESCRIPTION
This was added in https://github.com/danlehmann/arbitrary-int/pull/97 . Also bumping the version number as 2.1.0 is released on crates.io