### PR TITLE
Add missing panic docs

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -82,8 +82,12 @@ pub trait Integer:
 
     const IS_SIGNED: bool;
 
-    /// Creates a number from the given value, throwing an error if the value is too large.
+    /// Creates a number from the given value.
     /// This constructor is useful when creating a value from a literal.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is too large.
     fn new(value: Self::UnderlyingType) -> Self;
 
     /// Creates a number from the given value, return None if the value is too large
@@ -91,8 +95,12 @@ pub trait Integer:
 
     fn value(self) -> Self::UnderlyingType;
 
-    /// Creates a number from the given value, throwing an error if the value is too large.
+    /// Creates a number from the given value.
     /// This constructor is useful when the value is convertible to T. Use [`Self::new`] for literals.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is too large.
     fn from_<T: Integer>(value: T) -> Self;
 
     /// Creates an instance from the given `value`. Unlike the various `new...` functions, this
@@ -100,6 +108,10 @@ pub trait Integer:
     ///
     /// If the source value is a signed integer and the target has more bits, the value is
     /// sign-extended. For example, `u5::masked_new(i4::new(-1)) == u5::new(0b1_1111)`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `Self::BITS` is not one of 8, 16, 32, 64, 128.
     fn masked_new<T: Integer>(value: T) -> Self;
 
     fn as_u8(self) -> u8;

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -689,7 +689,7 @@ macro_rules! uint_impl {
                 #[must_use = "this returns the result of the operation, without modifying the original"]
                 pub const fn saturating_div(self, rhs: Self) -> Self {
                     // When dividing unsigned numbers, we never need to saturate.
-                    // Division by zero in saturating_div throws an exception (in debug and release mode),
+                    // Division by zero in saturating_div panics (in debug and release mode),
                     // so no need to do anything special there either
                     Self {
                         value: self.value().saturating_div(rhs.value()),
@@ -1454,7 +1454,7 @@ where
     type Output = UInt<T, BITS>;
 
     fn shl(self, rhs: TSHIFTBITS) -> Self::Output {
-        // With debug assertions, the << and >> operators throw an exception if the shift amount
+        // With debug assertions, the << and >> operators panic if the shift amount
         // is larger than the number of bits (in which case the result would always be 0)
         #[cfg(debug_assertions)]
         if rhs.try_into().unwrap_or(usize::MAX) >= BITS {
@@ -1476,7 +1476,7 @@ where
     Self: Integer,
 {
     fn shl_assign(&mut self, rhs: TSHIFTBITS) {
-        // With debug assertions, the << and >> operators throw an exception if the shift amount
+        // With debug assertions, the << and >> operators panic if the shift amount
         // is larger than the number of bits (in which case the result would always be 0)
         #[cfg(debug_assertions)]
         if rhs.try_into().unwrap_or(usize::MAX) >= BITS {
@@ -1496,7 +1496,7 @@ impl<
     type Output = UInt<T, BITS>;
 
     fn shr(self, rhs: TSHIFTBITS) -> Self::Output {
-        // With debug assertions, the << and >> operators throw an exception if the shift amount
+        // With debug assertions, the << and >> operators panic if the shift amount
         // is larger than the number of bits (in which case the result would always be 0)
         #[cfg(debug_assertions)]
         if rhs.try_into().unwrap_or(usize::MAX) >= BITS {
@@ -1515,7 +1515,7 @@ impl<
     > ShrAssign<TSHIFTBITS> for UInt<T, BITS>
 {
     fn shr_assign(&mut self, rhs: TSHIFTBITS) {
-        // With debug assertions, the << and >> operators throw an exception if the shift amount
+        // With debug assertions, the << and >> operators panic if the shift amount
         // is larger than the number of bits (in which case the result would always be 0)
         #[cfg(debug_assertions)]
         if rhs.try_into().unwrap_or(usize::MAX) >= BITS {

--- a/src/v1_number_compat.rs
+++ b/src/v1_number_compat.rs
@@ -31,8 +31,12 @@ pub trait Number: UnsignedInteger<UnderlyingType = <Self as Number>::UnderlyingT
     /// Maximum value that can be represented by this type
     const MAX: Self = <Self as Integer>::MAX;
 
-    /// Creates a number from the given value, throwing an error if the value is too large.
+    /// Creates a number from the given value.
     /// This constructor is useful when creating a value from a literal.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is too large.
     #[inline]
     fn new(value: <Self as Number>::UnderlyingType) -> Self {
         Integer::new(value)
@@ -49,8 +53,12 @@ pub trait Number: UnsignedInteger<UnderlyingType = <Self as Number>::UnderlyingT
         Integer::value(self)
     }
 
-    /// Creates a number from the given value, throwing an error if the value is too large.
+    /// Creates a number from the given value.
     /// This constructor is useful when the value is convertible to T. Use [`Self::new`] for literals.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is too large.
     #[inline]
     fn from_<T: Number>(value: T) -> Self {
         Integer::from_(value)


### PR DESCRIPTION
The panics docs are formatted in the same style as those in Rust's std. See https://doc.rust-lang.org/src/core/num/f32.rs.html#1411 for an example.