### PR TITLE
Add schemars v1 support

### DIFF
--- a/.github/workflows/test-serde.yml
+++ b/.github/workflows/test-serde.yml
@@ -14,3 +14,4 @@ jobs:
           cargo test --no-default-features --features=serde
           cargo test --no-default-features --features=serde,std
           cargo test --no-default-features --features=schemars
+          cargo test --no-default-features --features=schemars1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added optional `schemars` v1 support. Enable using the `schemars1` feature
+
 ## 2.1.1
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde = ["dep:serde"]
 borsh = ["dep:borsh"]
 
 schemars = ["dep:schemars", "std"]
+schemars1 = ["dep:schemars1", "std"]
 
 # Implement traits for bytemuck
 bytemuck = ["dep:bytemuck"]
@@ -50,6 +51,7 @@ defmt = { version = "1", optional = true }
 serde = { version = "1.0", optional = true, default-features = false }
 borsh = { version = "1.5.1", optional = true, features = ["unstable__schema"], default-features = false }
 schemars = { version = "0.8.21", optional = true, features = ["derive"], default-features = false }
+schemars1 = { package = "schemars", version = "1", optional = true, default-features = false }
 bytemuck = { version = "1", optional = true, default-features = false }
 bin-proto = { version = "0.12.2", optional = true, default-features = false }
 
@@ -58,3 +60,4 @@ quickcheck = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"
+serde_json = "1.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -290,6 +290,45 @@ macro_rules! impl_schemars {
                 Schema::Object(schema_object)
             }
         }
+
+        #[cfg(feature = "schemars1")]
+        impl<T: BuiltinInteger + $trait, const BITS: usize> schemars1::JsonSchema for $type<T, BITS>
+        where
+            Self: Integer,
+        {
+            fn inline_schema() -> bool {
+                true
+            }
+
+            fn schema_name() -> alloc::borrow::Cow<'static, str> {
+                use alloc::string::ToString;
+                [$str_prefix, &BITS.to_string()].concat().into()
+            }
+
+            fn json_schema(_gen: &mut schemars1::SchemaGenerator) -> schemars1::Schema {
+                // The `schemars` crate only provides the `minimum` and `maximum` fields for "small"
+                // integers (i8/u8/i16/u16).
+                //
+                // The rationale for this choice is explained in this issue:
+                // https://github.com/GREsau/schemars/issues/298
+                //
+                // We mimic that behavior and only provide the `minimum` and `maximum` fields for
+                // integers smaller than 32 bits.
+                if BITS < 32 {
+                    schemars1::json_schema!({
+                        "type": "integer",
+                        "format": Self::schema_name(),
+                        "minimum": Self::MIN.as_i64(),
+                        "maximum": Self::MAX.as_i64(),
+                    })
+                } else {
+                    schemars1::json_schema!({
+                        "type": "integer",
+                        "format": Self::schema_name(),
+                    })
+                }
+            }
+        }
     };
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4192,6 +4192,112 @@ fn schemars_signed() {
     assert_eq!(i8, i9);
 }
 
+#[cfg(feature = "schemars1")]
+#[test]
+fn schemars1_unsigned() {
+    use schemars1::{generate::SchemaSettings, schema_for};
+    use serde_json::json;
+
+    let meta = SchemaSettings::default().meta_schema.unwrap();
+
+    assert_eq!(
+        schema_for!(u1).to_value(),
+        json!({
+            "$schema": meta,
+            "type": "integer",
+            "format": "uint1",
+            "title": "uint1",
+            "minimum": 0,
+            "maximum": 1,
+        })
+    );
+
+    assert_eq!(
+        schema_for!(u31).to_value(),
+        json!({
+            "$schema": meta,
+            "type": "integer",
+            "format": "uint31",
+            "title": "uint31",
+            "minimum": 0,
+            "maximum": 0x7fffffff,
+        })
+    );
+
+    assert_eq!(
+        schema_for!(u33).to_value(),
+        json!({
+            "$schema": meta,
+            "type": "integer",
+            "format": "uint33",
+            "title": "uint33"
+        })
+    );
+
+    assert_eq!(
+        schema_for!(u127).to_value(),
+        json!({
+            "$schema": meta,
+            "type": "integer",
+            "format": "uint127",
+            "title": "uint127"
+        })
+    );
+}
+
+#[cfg(feature = "schemars1")]
+#[test]
+fn schemars1_signed() {
+    use schemars1::{generate::SchemaSettings, schema_for};
+    use serde_json::json;
+
+    let meta = SchemaSettings::default().meta_schema.unwrap();
+
+    assert_eq!(
+        schema_for!(i1).to_value(),
+        json!({
+            "$schema": meta,
+            "type": "integer",
+            "format": "int1",
+            "title": "int1",
+            "minimum": -1,
+            "maximum": 0,
+        })
+    );
+
+    assert_eq!(
+        schema_for!(i31).to_value(),
+        json!({
+            "$schema": meta,
+            "type": "integer",
+            "format": "int31",
+            "title": "int31",
+            "minimum": -0x40000000,
+            "maximum": 0x3fffffff,
+        })
+    );
+
+    assert_eq!(
+        schema_for!(i33).to_value(),
+        json!({
+            "$schema": meta,
+            "type": "integer",
+            "format": "int33",
+            "title": "int33"
+        })
+    );
+
+    assert_eq!(
+        schema_for!(i127).to_value(),
+        json!({
+            "$schema": meta,
+            "type": "integer",
+            "format": "int127",
+            "title": "int127"
+        })
+    );
+}
+
 #[cfg(feature = "bytemuck")]
 mod bytemuck {
     use arbitrary_int::prelude::*;


### PR DESCRIPTION
Adds optional [`schemars`](https://graham.cool/schemars/) v1 support via a new `schemars1` feature. Since v1 is a [breaking release](https://graham.cool/schemars/migrating/) with an incompatible API, it's exposed separately and the v1 dep is aliased so it coexists with the existing v0.8 `schemars` feature.

`JsonSchema` is implemented for `UInt`/`Int` through the preexisting `impl_schemars!` macro.

Following `schemars`' own handling of primitive integers, `minimum`/`maximum` are only emitted for integers smaller than 32 bits (see added code comment and https://github.com/GREsau/schemars/issues/298).

---

*AI disclosure: the implementation and tests were written by me. Claude Code assisted with fixing grammar in code comment, adding changelog and drafting this PR.*