### PR TITLE
Add Rkyv support

### DIFF
--- a/.github/workflows/test-rkyv.yml
+++ b/.github/workflows/test-rkyv.yml
@@ -1,0 +1,15 @@
+name: test rkyv
+run-name: ${{ github.actor }}'s patch
+on: [push, pull_request]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: true
+          toolchain: nightly
+      - run: |
+          cargo test --no-default-features --features=rkyv
+          cargo test --no-default-features --features=rkyv,std

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added optional `bytecheck` support. Enable using the `bytecheck` feature.
 - Added optional `schemars` v1 support. Enable using the `schemars1` feature.
 - Implemented `num_traits::Zero`.
+- Add support for the [rkyv](https://crates.io/crates/rkyv) crate using the optional `rkyv` feature.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ hint = []
 num-traits = { version = "0.2.19", default-features = false, optional = true }
 defmt = { version = "1", optional = true }
 serde = { version = "1.0", optional = true, default-features = false }
-rkyv = { version = "0.8.17", optional = true, default-features = false }
+rkyv = { version = "0.8.17", optional = true, default-features = false, features = ["bytecheck"] }
 borsh = { version = "1.5.1", optional = true, features = ["unstable__schema"], default-features = false }
 schemars = { version = "0.8.21", optional = true, features = ["derive"], default-features = false }
 schemars1 = { package = "schemars", version = "1", optional = true, default-features = false }
@@ -69,5 +69,5 @@ quickcheck = { version = "1", optional = true, default-features = false }
 [dev-dependencies]
 serde_test = "1.0"
 serde_json = "1.0"
-# Need the default `bytecheck` feature to tests without an unsafe block
-rkyv = { version = "0.8.17", default-features = true }
+# Need alloc for tests
+rkyv = { version = "0.8.17", default-features = false, features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ defmt = ["dep:defmt"]
 # Supports serde
 serde = ["dep:serde"]
 
+# Supports rkyv
+rkyv = ["dep:rkyv", "bytecheck"]
+
 borsh = ["dep:borsh"]
 
 schemars = ["dep:schemars", "std"]
@@ -52,6 +55,7 @@ hint = []
 num-traits = { version = "0.2.19", default-features = false, optional = true }
 defmt = { version = "1", optional = true }
 serde = { version = "1.0", optional = true, default-features = false }
+rkyv = { version = "0.8.17", optional = true, default-features = false }
 borsh = { version = "1.5.1", optional = true, features = ["unstable__schema"], default-features = false }
 schemars = { version = "0.8.21", optional = true, features = ["derive"], default-features = false }
 schemars1 = { package = "schemars", version = "1", optional = true, default-features = false }
@@ -65,3 +69,5 @@ quickcheck = { version = "1", optional = true, default-features = false }
 [dev-dependencies]
 serde_test = "1.0"
 serde_json = "1.0"
+# Need the default `bytecheck` feature to tests without an unsafe block
+rkyv = { version = "0.8.17", default-features = true }

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1582,12 +1582,15 @@ unsafe impl<
 where
     C::Error: rkyv::bytecheck::rancor::Source,
     Int<T, BITS>: Integer,
+    T: From<T::Archived>,
+    T::Archived: Copy,
 {
-    fn verify(&self, context: &mut C) -> Result<(), C::Error> {
-        let ptr: *const Int<T, BITS> = (&raw const self.value).cast();
-        // SAFETY: `in_subtree` was guaranteed called by [rkyv::api::checked::check_pos_with_context].
-        // Unsafe could later be replaced if rend add a trait to generically convert from <-> into native.
-        unsafe { (*ptr).verify(context) }
+    fn verify(&self, _context: &mut C) -> Result<(), C::Error> {
+        let native: T = self.value.into();
+        if native > Int::<T, BITS>::MAX.value || native < Int::<T, BITS>::MIN.value {
+            rkyv::bytecheck::rancor::fail!(TryNewError);
+        }
+        Ok(())
     }
 }
 

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -139,6 +139,10 @@ impl_signed_integer_native!((i8, u8), (i16, u16), (i32, u32), (i64, u64), (i128,
 #[derive(Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "bytecheck", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "bytecheck", bytecheck(verify))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 #[repr(transparent)]
 pub struct Int<T: SignedInteger + BuiltinInteger, const BITS: usize> {
     value: T,

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -141,14 +141,8 @@ impl_signed_integer_native!((i8, u8), (i16, u16), (i32, u32), (i64, u64), (i128,
 #[cfg_attr(feature = "bytecheck", bytecheck(verify))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize, rkyv::Portable),
-    rkyv(
-        archive_bounds(
-            T: rkyv::Archive<Archived = T> + rkyv::Portable,
-            <T as rkyv::Archive>::Archived: SignedInteger + BuiltinInteger,
-        ),
-        as = Self,
-    )
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    rkyv(bytecheck(verify))
 )]
 #[repr(transparent)]
 pub struct Int<T: SignedInteger + BuiltinInteger, const BITS: usize> {
@@ -1576,6 +1570,24 @@ where
             bytecheck::rancor::fail!(TryNewError);
         }
         Ok(())
+    }
+}
+
+#[cfg(feature = "rkyv")]
+unsafe impl<
+        T: SignedInteger + BuiltinInteger + rkyv::Archive,
+        const BITS: usize,
+        C: rkyv::bytecheck::rancor::Fallible + ?Sized,
+    > rkyv::bytecheck::Verify<C> for ArchivedInt<T, BITS>
+where
+    C::Error: rkyv::bytecheck::rancor::Source,
+    Int<T, BITS>: Integer,
+{
+    fn verify(&self, context: &mut C) -> Result<(), C::Error> {
+        let ptr: *const Int<T, BITS> = (&raw const self.value).cast();
+        // SAFETY: `in_subtree` was guaranteed called by [rkyv::api::checked::check_pos_with_context].
+        // Unsafe could later be replaced if rend add a trait to generically convert from <-> into native.
+        unsafe { (*ptr).verify(context) }
     }
 }
 

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -141,7 +141,14 @@ impl_signed_integer_native!((i8, u8), (i16, u16), (i32, u32), (i64, u64), (i128,
 #[cfg_attr(feature = "bytecheck", bytecheck(verify))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize, rkyv::Portable),
+    rkyv(
+        archive_bounds(
+            T: rkyv::Archive<Archived = T> + rkyv::Portable,
+            <T as rkyv::Archive>::Archived: SignedInteger + BuiltinInteger,
+        ),
+        as = Self,
+    )
 )]
 #[repr(transparent)]
 pub struct Int<T: SignedInteger + BuiltinInteger, const BITS: usize> {

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -127,6 +127,10 @@ impl_integer_native!((u8, i8), (u16, i16), (u32, i32), (u64, i64), (u128, i128))
 #[derive(Copy, Clone, Eq, PartialEq, Default, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "bytecheck", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "bytecheck", bytecheck(verify))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
 #[repr(transparent)]
 pub struct UInt<T: UnsignedInteger + BuiltinInteger, const BITS: usize> {
     value: T,

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -129,7 +129,14 @@ impl_integer_native!((u8, i8), (u16, i16), (u32, i32), (u64, i64), (u128, i128))
 #[cfg_attr(feature = "bytecheck", bytecheck(verify))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize, rkyv::Portable),
+    rkyv(
+        archive_bounds(
+            T: rkyv::Archive<Archived = T> + rkyv::Portable,
+            <T as rkyv::Archive>::Archived: UnsignedInteger + BuiltinInteger,
+        ),
+        as = Self,
+    )
 )]
 #[repr(transparent)]
 pub struct UInt<T: UnsignedInteger + BuiltinInteger, const BITS: usize> {

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -129,14 +129,8 @@ impl_integer_native!((u8, i8), (u16, i16), (u32, i32), (u64, i64), (u128, i128))
 #[cfg_attr(feature = "bytecheck", bytecheck(verify))]
 #[cfg_attr(
     feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize, rkyv::Portable),
-    rkyv(
-        archive_bounds(
-            T: rkyv::Archive<Archived = T> + rkyv::Portable,
-            <T as rkyv::Archive>::Archived: UnsignedInteger + BuiltinInteger,
-        ),
-        as = Self,
-    )
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
+    rkyv(bytecheck(verify))
 )]
 #[repr(transparent)]
 pub struct UInt<T: UnsignedInteger + BuiltinInteger, const BITS: usize> {
@@ -189,6 +183,24 @@ where
             bytecheck::rancor::fail!(TryNewError);
         }
         Ok(())
+    }
+}
+
+#[cfg(feature = "rkyv")]
+unsafe impl<
+        T: UnsignedInteger + BuiltinInteger + rkyv::Archive,
+        const BITS: usize,
+        C: rkyv::bytecheck::rancor::Fallible + ?Sized,
+    > rkyv::bytecheck::Verify<C> for ArchivedUInt<T, BITS>
+where
+    C::Error: rkyv::bytecheck::rancor::Source,
+    UInt<T, BITS>: Integer,
+{
+    fn verify(&self, context: &mut C) -> Result<(), C::Error> {
+        let ptr: *const UInt<T, BITS> = (&raw const self.value).cast();
+        // SAFETY: `in_subtree` was guaranteed called by [rkyv::api::checked::check_pos_with_context].
+        // Unsafe could later be replaced if rend add a trait to generically convert from <-> into native.
+        unsafe { (*ptr).verify(context) }
     }
 }
 

--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -195,12 +195,15 @@ unsafe impl<
 where
     C::Error: rkyv::bytecheck::rancor::Source,
     UInt<T, BITS>: Integer,
+    T: From<T::Archived>,
+    T::Archived: Copy,
 {
-    fn verify(&self, context: &mut C) -> Result<(), C::Error> {
-        let ptr: *const UInt<T, BITS> = (&raw const self.value).cast();
-        // SAFETY: `in_subtree` was guaranteed called by [rkyv::api::checked::check_pos_with_context].
-        // Unsafe could later be replaced if rend add a trait to generically convert from <-> into native.
-        unsafe { (*ptr).verify(context) }
+    fn verify(&self, _context: &mut C) -> Result<(), C::Error> {
+        let native: T = self.value.into();
+        if native > UInt::<T, BITS>::MAX.value {
+            rkyv::bytecheck::rancor::fail!(TryNewError);
+        }
+        Ok(())
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3797,6 +3797,34 @@ fn serde_signed() {
     assert_de_tokens(&i7::MAX, &[Token::U8(i7::MAX.value() as u8)]);
 }
 
+#[cfg(feature = "rkyv")]
+mod rkyv {
+    use arbitrary_int::prelude::*;
+    use rkyv::rancor::Error as RkyvError;
+
+    #[test]
+    fn unisgned() {
+        let expected = u7::MAX;
+        let bytes = rkyv::to_bytes::<RkyvError>(&expected).unwrap();
+        let actual = rkyv::access::<ArchivedUInt<_, _>, RkyvError>(&bytes[..])
+            .and_then(rkyv::deserialize)
+            .unwrap();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn signed() {
+        let expected = i7::MAX;
+        let bytes = rkyv::to_bytes::<RkyvError>(&expected).unwrap();
+        let actual = rkyv::access::<ArchivedInt<_, _>, RkyvError>(&bytes[..])
+            .and_then(rkyv::deserialize)
+            .unwrap();
+
+        assert_eq!(expected, actual);
+    }
+}
+
 #[cfg(feature = "num-traits")]
 mod num_traits {
     use arbitrary_int::prelude::*;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3796,19 +3796,17 @@ fn serde_signed() {
     assert_de_tokens(&i7::new(15), &[Token::U8(15)]);
     assert_de_tokens(&i7::MAX, &[Token::U8(i7::MAX.value() as u8)]);
 }
-
 #[cfg(feature = "rkyv")]
 mod rkyv {
     use arbitrary_int::prelude::*;
-    use rkyv::rancor::Error as RkyvError;
+    use bytecheck::{check_bytes, Verify};
+    use rkyv::rancor::{Error as RkyvError, Strategy};
 
     #[test]
     fn unisgned() {
         let expected = u7::MAX;
         let bytes = rkyv::to_bytes::<RkyvError>(&expected).unwrap();
-        let actual = rkyv::access::<ArchivedUInt<_, _>, RkyvError>(&bytes[..])
-            .and_then(rkyv::deserialize)
-            .unwrap();
+        let actual = *rkyv::access::<UInt<_, _>, RkyvError>(&bytes[..]).unwrap();
 
         assert_eq!(expected, actual);
     }
@@ -3817,11 +3815,27 @@ mod rkyv {
     fn signed() {
         let expected = i7::MAX;
         let bytes = rkyv::to_bytes::<RkyvError>(&expected).unwrap();
-        let actual = rkyv::access::<ArchivedInt<_, _>, RkyvError>(&bytes[..])
-            .and_then(rkyv::deserialize)
-            .unwrap();
+        let actual = *rkyv::access::<Int<_, _>, RkyvError>(&bytes[..]).unwrap();
 
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn invalid_out_of_range() {
+        let temp = &mut ();
+        let ctx: &mut Strategy<(), rkyv::rancor::Failure> = Strategy::wrap(temp);
+
+        // This work
+        let u1 = unsafe { u1::new_unchecked(123) };
+        u1.verify(ctx).unwrap_err();
+
+        // This work
+        let wrong = 123;
+        unsafe { check_bytes::<u1, rkyv::rancor::Failure>((&raw const wrong).cast()).unwrap_err() };
+
+        // This doesn't. &[123_u8] does work
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&[123_u8, 0_u8]).unwrap();
+        rkyv::access::<u1, rkyv::rancor::Error>(&bytes[..]).unwrap_err();
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3835,6 +3835,28 @@ mod rkyv {
     }
 
     #[test]
+    fn multi_byte_roundtrip() {
+        // Multi-byte values are stored with a fixed endianness in the archive,
+        // so verification must convert to native before range-checking. On a
+        // mismatched-endian host (or with rkyv's `big_endian` feature on a
+        // little-endian one), reinterpreting the archived bytes natively would
+        // reject valid values like these and accept out-of-range ones.
+        let expected = u9::new(300);
+        let bytes = rkyv::to_bytes::<RkyvError>(&expected).unwrap();
+        let actual = rkyv::access::<ArchivedUInt<u16, 9>, RkyvError>(&bytes[..])
+            .and_then(rkyv::deserialize)
+            .unwrap();
+        assert_eq!(expected, actual);
+
+        let expected = i9::new(-200);
+        let bytes = rkyv::to_bytes::<RkyvError>(&expected).unwrap();
+        let actual = rkyv::access::<ArchivedInt<i16, 9>, RkyvError>(&bytes[..])
+            .and_then(rkyv::deserialize)
+            .unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn endianness_shenanigans() {
         // Rkyv internally use [rend](https://github.com/rkyv/rend) to deal with cross platform number endianness.
         // This make sure that our implementation respect this.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3799,14 +3799,15 @@ fn serde_signed() {
 #[cfg(feature = "rkyv")]
 mod rkyv {
     use arbitrary_int::prelude::*;
-    use bytecheck::{check_bytes, Verify};
-    use rkyv::rancor::{Error as RkyvError, Strategy};
+    use rkyv::rancor::Error as RkyvError;
 
     #[test]
     fn unisgned() {
         let expected = u7::MAX;
         let bytes = rkyv::to_bytes::<RkyvError>(&expected).unwrap();
-        let actual = *rkyv::access::<UInt<_, _>, RkyvError>(&bytes[..]).unwrap();
+        let actual = rkyv::access::<ArchivedUInt<_, _>, RkyvError>(&bytes[..])
+            .and_then(rkyv::deserialize)
+            .unwrap();
 
         assert_eq!(expected, actual);
     }
@@ -3815,27 +3816,34 @@ mod rkyv {
     fn signed() {
         let expected = i7::MAX;
         let bytes = rkyv::to_bytes::<RkyvError>(&expected).unwrap();
-        let actual = *rkyv::access::<Int<_, _>, RkyvError>(&bytes[..]).unwrap();
+        let actual = rkyv::access::<ArchivedInt<_, _>, RkyvError>(&bytes[..])
+            .and_then(rkyv::deserialize)
+            .unwrap();
 
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn invalid_out_of_range() {
-        let temp = &mut ();
-        let ctx: &mut Strategy<(), rkyv::rancor::Failure> = Strategy::wrap(temp);
+        let bytes = rkyv::to_bytes::<RkyvError>(&[123_u8, 123_u8]).unwrap();
+        rkyv::access::<ArchivedUInt<u16, 9>, RkyvError>(&bytes)
+            .and_then(rkyv::deserialize)
+            .unwrap_err();
+        rkyv::access::<ArchivedInt<i16, 9>, RkyvError>(&bytes)
+            .and_then(rkyv::deserialize)
+            .unwrap_err();
+    }
 
-        // This work
-        let u1 = unsafe { u1::new_unchecked(123) };
-        u1.verify(ctx).unwrap_err();
-
-        // This work
-        let wrong = 123;
-        unsafe { check_bytes::<u1, rkyv::rancor::Failure>((&raw const wrong).cast()).unwrap_err() };
-
-        // This doesn't. &[123_u8] does work
-        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&[123_u8, 0_u8]).unwrap();
-        rkyv::access::<u1, rkyv::rancor::Error>(&bytes[..]).unwrap_err();
+    #[test]
+    fn endianness_shenanigans() {
+        // Rkyv internally use [rend](https://github.com/rkyv/rend) to deal with cross platform number endianness.
+        // This make sure that our implementation respect this.
+        // If it doesn't, compile fail on the derive of rkyv.
+        #[derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+        struct Archivable {
+            uint: (u1, u9, u17, u33, u65, u127),
+            int: (i1, i9, i17, i33, i65, i127),
+        }
     }
 }
 


### PR DESCRIPTION
In the same vein as Serde, add [Rkyv](https://crates.io/crates/rkyv) support with an optional feature.

An example (and also my) use case is for writing savestates for an emulator. Rkyv is really good at making small ser file, and combining it with arbitrary-int for type system invariant fits well.

The code seems weirdly simple too but the tests cases works fine.