### PR TITLE
Fix broken intra-doc links in UInt docs

### DIFF
--- a/src/unsigned.rs
+++ b/src/unsigned.rs
@@ -120,7 +120,7 @@ impl_integer_native!((u8, i8), (u16, i16), (u32, i32), (u64, i64), (u128, i128))
 ///
 /// # Representation
 /// The result of [`Self::value`] is guaranteed to match the in-memory representation
-/// that would be seen by [`mem::transmute`] or [`bytemuck::cast`].
+/// that would be seen by [`core::mem::transmute`] or `bytemuck::cast`.
 /// So as long as the value is valid, it is safe to transmute back and forth from `T`.
 ///
 /// When `cfg(feature = "bytemuck")` is set, the appropriate bytemuck traits will be implemented.


### PR DESCRIPTION
Rustdoc failed with -D warnings because `mem::transmute` was not in scope and `bytemuck` is an optional dependency not available when building docs. Use the full `core::mem::transmute` path and drop the link on `bytemuck::cast`, matching the wording in signed.rs.